### PR TITLE
Add metadata to build as a dep of libstd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: ci
 on:
   pull_request:
+    branches:
+    - master
   push:
     branches:
     - master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,17 @@ std = []
 # then, it is alias for the 'std' feature.
 use_std = ["std"]
 
+# Internal feature, only used when building as part of libstd, not part of the
+# stable interface of this crate.
+rustc-dep-of-std = ['core', 'compiler_builtins']
+
 [dependencies]
 libc = { version = "0.2.18", default-features = false, optional = true }
+
+# Internal feature, only used when building as part of libstd, not part of the
+# stable interface of this crate.
+core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
+compiler_builtins = { version = '0.1.2', optional = true }
 
 [dev-dependencies]
 quickcheck = { version = "1.0.3", default-features = false }


### PR DESCRIPTION
This commit adds the necessary `Cargo.toml` directives which enables
this crate to build with the standard library. This introduces some
optional off-by-deault dependencies which are only activated (and
overwritten) when built as part of the standard library.