### PR TITLE
doc: find_iter, rfind_iter return non-overlapping matches

### DIFF
--- a/src/memmem/mod.rs
+++ b/src/memmem/mod.rs
@@ -159,7 +159,8 @@ mod vector;
 #[cfg(all(not(miri), target_arch = "x86_64", memchr_runtime_simd))]
 mod x86;
 
-/// Returns an iterator over all occurrences of a substring in a haystack.
+/// Returns an iterator over all non-overlapping occurrences of a substring in
+/// a haystack.
 ///
 /// # Complexity
 ///
@@ -192,8 +193,8 @@ pub fn find_iter<'h, 'n, N: 'n + ?Sized + AsRef<[u8]>>(
     FindIter::new(haystack, Finder::new(needle))
 }
 
-/// Returns a reverse iterator over all occurrences of a substring in a
-/// haystack.
+/// Returns a reverse iterator over all non-overlapping occurrences of a
+/// substring in a haystack.
 ///
 /// # Complexity
 ///


### PR DESCRIPTION
The documentation for FindIter and FindRevIter already include this
detail. However, it was not immediately clear to me from the
documentation what find_iter and rfind_iter do about overlapping
matches. Add "non-overlapping" to the description.