### PR TITLE
Derive clone on iterators.

### DIFF
--- a/src/memchr/iter.rs
+++ b/src/memchr/iter.rs
@@ -31,6 +31,7 @@ macro_rules! iter_next_back {
 }
 
 /// An iterator for `memchr`.
+#[derive(Clone)]
 pub struct Memchr<'a> {
     needle: u8,
     // The haystack to iterate over
@@ -69,6 +70,7 @@ impl<'a> DoubleEndedIterator for Memchr<'a> {
 }
 
 /// An iterator for `memchr2`.
+#[derive(Clone)]
 pub struct Memchr2<'a> {
     needle1: u8,
     needle2: u8,
@@ -116,6 +118,7 @@ impl<'a> DoubleEndedIterator for Memchr2<'a> {
 }
 
 /// An iterator for `memchr3`.
+#[derive(Clone)]
 pub struct Memchr3<'a> {
     needle1: u8,
     needle2: u8,


### PR DESCRIPTION
Ran into a case where I needed cloneable iterators due to some generic constraints. Most iterators in std are cloneable, but these weren't. Now they are!