### PR TITLE
simd: support AVX2 detection without std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,7 @@ bench = false
 [features]
 default = ["std"]
 
-# The 'std' feature permits the memchr crate to use the standard library. This
-# permits this crate to use runtime CPU feature detection to automatically
-# accelerate searching via vector instructions. Without the standard library,
-# this automatic detection is not possible.
+# The 'std' feature permits the memchr crate to use the standard library.
 std = []
 # The 'use_std' feature is DEPRECATED. It will be removed in memchr 3. Until
 # then, it is alias for the 'std' feature.

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ memchr links to the standard library by default, but you can disable the
 memchr = { version = "2", default-features = false }
 ```
 
-On x86 platforms, when the `std` feature is disabled, the SSE2 accelerated
-implementations will be used. When `std` is enabled, AVX accelerated
+On x86_64 platforms, the AVX accelerated
 implementations will be used if the CPU is determined to support it at runtime.
+Otherwise the SSE2 accelerated implementations will be used.
 
 ### Using libc
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,3 +179,5 @@ mod memchr;
 pub mod memmem;
 #[cfg(test)]
 mod tests;
+#[cfg(target_arch = "x86_64")]
+mod x86_detect;

--- a/src/memmem/prefilter/mod.rs
+++ b/src/memmem/prefilter/mod.rs
@@ -298,15 +298,10 @@ pub(crate) fn forward(
 
     #[cfg(all(not(miri), target_arch = "x86_64", memchr_runtime_simd))]
     {
-        #[cfg(feature = "std")]
-        {
-            if cfg!(memchr_runtime_avx) {
-                if is_x86_feature_detected!("avx2") {
-                    // SAFETY: x86::avx::find only requires the avx2 feature,
-                    // which we've just checked above.
-                    return unsafe { Some(PrefilterFn::new(x86::avx::find)) };
-                }
-            }
+        if cfg!(memchr_runtime_avx) && crate::x86_detect::is_avx2_enabled() {
+            // SAFETY: x86::avx::find only requires the avx2 feature,
+            // which we've just checked above.
+            return unsafe { Some(PrefilterFn::new(x86::avx::find)) };
         }
         if cfg!(memchr_runtime_sse2) {
             // SAFETY: x86::sse::find only requires the sse2 feature, which is

--- a/src/memmem/prefilter/x86/avx.rs
+++ b/src/memmem/prefilter/x86/avx.rs
@@ -33,7 +33,7 @@ pub(crate) unsafe fn find(
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(not(miri))]
+    #[cfg(all(feature = "std", not(miri)))]
     fn prefilter_permutations() {
         use crate::memmem::prefilter::tests::PrefilterTest;
         if !is_x86_feature_detected!("avx2") {

--- a/src/memmem/prefilter/x86/mod.rs
+++ b/src/memmem/prefilter/x86/mod.rs
@@ -1,5 +1,2 @@
-// We only use AVX when we can detect at runtime whether it's available, which
-// requires std.
-#[cfg(feature = "std")]
 pub(crate) mod avx;
 pub(crate) mod sse;

--- a/src/memmem/vector.rs
+++ b/src/memmem/vector.rs
@@ -64,7 +64,7 @@ mod x86sse {
     }
 }
 
-#[cfg(all(feature = "std", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 mod x86avx {
     use super::Vector;
     use core::arch::x86_64::*;

--- a/src/memmem/x86/avx.rs
+++ b/src/memmem/x86/avx.rs
@@ -1,101 +1,60 @@
-#[cfg(not(feature = "std"))]
-pub(crate) use self::nostd::Forward;
-#[cfg(feature = "std")]
-pub(crate) use self::std::Forward;
+use core::arch::x86_64::{__m128i, __m256i};
 
-#[cfg(feature = "std")]
-mod std {
-    use core::arch::x86_64::{__m128i, __m256i};
+use crate::memmem::{genericsimd, NeedleInfo};
+use crate::x86_detect;
 
-    use crate::memmem::{genericsimd, NeedleInfo};
+/// An AVX accelerated vectorized substring search routine that only works
+/// on small needles.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Forward(genericsimd::Forward);
 
-    /// An AVX accelerated vectorized substring search routine that only works
-    /// on small needles.
-    #[derive(Clone, Copy, Debug)]
-    pub(crate) struct Forward(genericsimd::Forward);
-
-    impl Forward {
-        /// Create a new "generic simd" forward searcher. If one could not be
-        /// created from the given inputs, then None is returned.
-        pub(crate) fn new(
-            ninfo: &NeedleInfo,
-            needle: &[u8],
-        ) -> Option<Forward> {
-            if !cfg!(memchr_runtime_avx) || !is_x86_feature_detected!("avx2") {
-                return None;
-            }
-            genericsimd::Forward::new(ninfo, needle).map(Forward)
+impl Forward {
+    /// Create a new "generic simd" forward searcher. If one could not be
+    /// created from the given inputs, then None is returned.
+    pub(crate) fn new(ninfo: &NeedleInfo, needle: &[u8]) -> Option<Forward> {
+        if !cfg!(memchr_runtime_avx) || !x86_detect::is_avx2_enabled() {
+            return None;
         }
-
-        /// Returns the minimum length of haystack that is needed for this
-        /// searcher to work. Passing a haystack with a length smaller than
-        /// this will cause `find` to panic.
-        #[inline(always)]
-        pub(crate) fn min_haystack_len(&self) -> usize {
-            self.0.min_haystack_len::<__m128i>()
-        }
-
-        #[inline(always)]
-        pub(crate) fn find(
-            &self,
-            haystack: &[u8],
-            needle: &[u8],
-        ) -> Option<usize> {
-            // SAFETY: The only way a Forward value can exist is if the avx2
-            // target feature is enabled. This is the only safety requirement
-            // for calling the genericsimd searcher.
-            unsafe { self.find_impl(haystack, needle) }
-        }
-
-        /// The implementation of find marked with the appropriate target
-        /// feature.
-        ///
-        /// # Safety
-        ///
-        /// Callers must ensure that the avx2 CPU feature is enabled in the
-        /// current environment.
-        #[target_feature(enable = "avx2")]
-        unsafe fn find_impl(
-            &self,
-            haystack: &[u8],
-            needle: &[u8],
-        ) -> Option<usize> {
-            if haystack.len() < self.0.min_haystack_len::<__m256i>() {
-                genericsimd::fwd_find::<__m128i>(&self.0, haystack, needle)
-            } else {
-                genericsimd::fwd_find::<__m256i>(&self.0, haystack, needle)
-            }
-        }
+        genericsimd::Forward::new(ninfo, needle).map(Forward)
     }
-}
 
-// We still define the avx "forward" type on nostd to make caller code a bit
-// simpler. This avoids needing a lot more conditional compilation.
-#[cfg(not(feature = "std"))]
-mod nostd {
-    use crate::memmem::NeedleInfo;
+    /// Returns the minimum length of haystack that is needed for this
+    /// searcher to work. Passing a haystack with a length smaller than
+    /// this will cause `find` to panic.
+    #[inline(always)]
+    pub(crate) fn min_haystack_len(&self) -> usize {
+        self.0.min_haystack_len::<__m128i>()
+    }
 
-    #[derive(Clone, Copy, Debug)]
-    pub(crate) struct Forward(());
+    #[inline(always)]
+    pub(crate) fn find(
+        &self,
+        haystack: &[u8],
+        needle: &[u8],
+    ) -> Option<usize> {
+        // SAFETY: The only way a Forward value can exist is if the avx2
+        // target feature is enabled. This is the only safety requirement
+        // for calling the genericsimd searcher.
+        unsafe { self.find_impl(haystack, needle) }
+    }
 
-    impl Forward {
-        pub(crate) fn new(
-            ninfo: &NeedleInfo,
-            needle: &[u8],
-        ) -> Option<Forward> {
-            None
-        }
-
-        pub(crate) fn min_haystack_len(&self) -> usize {
-            unreachable!()
-        }
-
-        pub(crate) fn find(
-            &self,
-            haystack: &[u8],
-            needle: &[u8],
-        ) -> Option<usize> {
-            unreachable!()
+    /// The implementation of find marked with the appropriate target
+    /// feature.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure that the avx2 CPU feature is enabled in the
+    /// current environment.
+    #[target_feature(enable = "avx2")]
+    unsafe fn find_impl(
+        &self,
+        haystack: &[u8],
+        needle: &[u8],
+    ) -> Option<usize> {
+        if haystack.len() < self.0.min_haystack_len::<__m256i>() {
+            genericsimd::fwd_find::<__m128i>(&self.0, haystack, needle)
+        } else {
+            genericsimd::fwd_find::<__m256i>(&self.0, haystack, needle)
         }
     }
 }

--- a/src/x86_detect.rs
+++ b/src/x86_detect.rs
@@ -1,0 +1,114 @@
+/// Feature detection for AVX2.
+///
+/// This function is equivalent to `std::is_x86_feature_detected!("avx2")`.
+#[inline]
+#[cfg(all(not(test), feature = "std"))]
+pub fn is_avx2_enabled() -> bool {
+    std::is_x86_feature_detected!("avx2")
+}
+
+/// `no_std` feature detection for AVX2.
+///
+/// This function is equivalent to `std::is_x86_feature_detected!("avx2")`.
+#[inline]
+#[cfg(any(test, not(feature = "std")))]
+pub fn is_avx2_enabled() -> bool {
+    use core::sync::atomic::{AtomicU8, Ordering};
+
+    if cfg!(target_feature = "avx2") {
+        return true;
+    }
+
+    if cfg!(target_env = "sgx") {
+        // CPUID isn't available on SGX
+        return false;
+    }
+
+    const UNINIT: u8 = 0b00;
+    const ENABLED: u8 = 0b01;
+    const DISABLED: u8 = 0b10;
+    static CACHE: AtomicU8 = AtomicU8::new(UNINIT);
+
+    let cached = CACHE.load(Ordering::Relaxed);
+    if cached != UNINIT {
+        cached == ENABLED
+    } else {
+        #[cold]
+        fn detect_and_init() -> bool {
+            let value = detect_avx2_enabled();
+            CACHE.store(
+                if value { ENABLED } else { DISABLED },
+                Ordering::Relaxed,
+            );
+            value
+        }
+
+        detect_and_init()
+    }
+}
+
+// References:
+// https://en.wikipedia.org/wiki/CPUID
+// https://en.wikipedia.org/wiki/Control_register#XCR0_and_XSS
+// https://software.intel.com/en-us/blogs/2011/04/14/is-avx-enabled/
+// https://www.intel.com/content/dam/develop/external/us/en/documents/36945 §2.2
+#[cfg(any(test, not(feature = "std")))]
+fn detect_avx2_enabled() -> bool {
+    use core::arch::x86_64::*;
+
+    if cfg!(target_env = "sgx") {
+        // CPUID isn't available on SGX
+        return false;
+    }
+
+    // EAX=0: Highest Function Parameter
+    let max_basic_leaf = unsafe { __cpuid(0).eax };
+    if max_basic_leaf < 7 {
+        // CPUID doesn't support "Extended Features"
+        return false;
+    }
+
+    // EAX=7, ECX=0: Extended Features
+    let extended_features_ebx = unsafe { __cpuid(7).ebx };
+    if extended_features_ebx & (1 << 5) == 0 {
+        // CPU doesn't support AVX2
+        return false;
+    }
+
+    // EAX=1: Processor Info and Feature Bits
+    let proc_info_ecx = unsafe { __cpuid(1).ecx };
+
+    // Check XSAVE support.
+    // This is required for the OS to save and restore the AVX state
+    let xsave = proc_info_ecx & (1 << 26) != 0;
+    if !xsave {
+        return false;
+    }
+
+    // Check if XSAVE is enabled by the OS
+    let osxsave = proc_info_ecx & (1 << 27) != 0;
+    if !osxsave {
+        return false;
+    }
+
+    // Check if the OS has set the following bits in XCR0.
+    // .bit 1 = SSE enable
+    // .bit 2 = AVX enable
+    let xcr0 = unsafe { _xgetbv(0) };
+    if xcr0 & 0b110 == 0 {
+        return false;
+    }
+
+    true
+}
+
+#[cfg(all(test, feature = "std", not(miri)))]
+mod tests {
+    #[test]
+    fn detect_avx2() {
+        assert_eq!(
+            super::is_avx2_enabled(),
+            std::is_x86_feature_detected!("avx2")
+        );
+    }
+}

--- a/src/x86_detect.rs
+++ b/src/x86_detect.rs
@@ -95,7 +95,7 @@ fn detect_avx2_enabled() -> bool {
     // .bit 1 = SSE enable
     // .bit 2 = AVX enable
     let xcr0 = unsafe { _xgetbv(0) };
-    if xcr0 & 0b110 == 0 {
+    if xcr0 & 0b110 != 0b110 {
         return false;
     }
 


### PR DESCRIPTION
### Summary

This PR implements AVX2 runtime feature detection that works in `no_std` using the `cpuid` instruction.

### Motivation

`memchr` provides low-level primitives, and it's unfortunate that we cannot make use of the most performant implementation without bringing in `libstd`. And there's no good reason for it, either — unlike other architectures, detecting CPU features on x86 isn't OS dependent (see [this comment](https://github.com/rust-lang/stdarch/issues/464#issuecomment-637243355)).

The proper solution would be to wait until `is_x86_feature_detected` is available in `libcore`, but that probably won't happen any time soon. In the meantime, I'd like to propose doing it ourselves as a stopgap measure.

### Drawbacks

* This adds an amount of low-level complexity to the crate. Getting information from `cpuid` isn't the simplest thing and involves a lot of details to get right. However, compared to writing complex SIMD routines by hand, I believe it should be relatively manageable.

* The maintenance burden should be neglectable, since we only care about one feature and the CPUID "protocol" can never change, no reason to touch it in the future.

### Rationale and alternatives

* Not doing this. The real life use cases for the `no_std` + `x86_64` + `performance critical` combo aren't the most plentiful. I'm not sure how many people would actually have a need for this, besides "it's nice to have". Boils down to cost-benefit analysis.

* Use another crate to do the detection for us.
  * This brings in extra dependencies.
  * [`raw-cpuid`](https://crates.io/crates/raw-cpuid) supports *everything* related to `cpuid`, and it's quite large as a result. Is the extra compile time worth it?
  * [`cpufeatures`](https://crates.io/crates/cpufeatures) is much more lightweight, but it's detection logic is actually faulty — same issue as [gcc#85100](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85100), [glibc#13007](https://sourceware.org/bugzilla/show_bug.cgi?id=13007), [etc](https://developer.blender.org/T38815).

* Fall back to `#[cfg(target_feature)]` compile-time detection for `no_std`.
  * This needs to be enabled manually for the end users, but requires the least amount of effort to implement.
  * The [Steam Hardware Survey](https://store.steampowered.com/hwsurvey) shows that 87% of Steam users have AVX2 support. While this survery is biased for higher-end gaming PCs, I think it's still fair to say that AVX2 is fairly common nowadays. It makes sense for people to enable it unconditionally, depending on their target demographics.

### Prior art

* `getrandom` uses `cpuid` to [detect `rdrand`](https://github.com/rust-random/getrandom/blob/v0.2.6/src/rdrand.rs#L65-L69).
* `rdrand` also [do this](https://github.com/nagisa/rust_rdrand/issues/5) when the `std` feature is disabled.
* Most crates under [RustCrypto](https://github.com/RustCrypto) are `no_std`, which use the previously mentioned [`cpufeatures`](https://crates.io/crates/cpufeatures) crate for feature detection.
* [simdutf8](https://github.com/rusticstuff/simdutf8) does `target_feature` compile-time detection in `no_std`.