### PR TITLE
Add support for optional runtime selection of byte-frequency table.

### DIFF
--- a/src/memmem/mod.rs
+++ b/src/memmem/mod.rs
@@ -66,7 +66,7 @@ assert_eq!(None, finder.find(b"quux baz bar"));
 ```
 */
 
-pub use self::prefilter::Prefilter;
+pub use self::{prefilter::Prefilter, rarebytes::set_byte_frequencies};
 
 use crate::{
     cow::CowBytes,


### PR DESCRIPTION
I propose a small change to `src/memmem/rarebytes.rs` that will allow users to optionally choose a different byte-frequency table at runtime.

I am writing a library that scans for byte patterns in the memory of an executing process. The algorithm used by `memchr` would be ideal for scanning byte patterns of non-aligned length (i.e. 13 bytes). However, the performance of the algorithm is highly dependent upon the prefilter, which itself is highly dependent on the quality of the byte frequency table used to implement the prefilter. While the table in `memchr::memmem::byte_frequencies` is very good for most cases, in the specific case of searching through the memory of a binary executable it is less than optimal.

You can see this immediately by just considering the `\x00` byte. If you count the most frequent bytes found in binary executables, the `\x00' byte has a frequency that is almost an order of magnitude higher than the next most frequent byte ('H'). This makes sense, since integers use zero bytes for padding (e.g. 5u32 in bytes is [0, 0, 0, 5]).

However, in the default byte frequency table the `\x00` byte is not even particularly frequent. This makes perfect sense for most inputs, but results in dramatically less throughput when scanning binary executables.

The main change is to store a static pointer to the 'current frequency table' and use the stored pointer when calculating the rank for a byte in `memchr::memmem::rarebytes::rank`. Here are some justifications (see comments for more details):

- A static global is used to be as un-intrusive as possible on the rest of the API.
- A pointer is used so that modifications can be done atomically with `AtomicUsize`.
- `AtomicUsize` is used due to performance and thread safety.
- `AtomicPtr` is avoided since the pointer that is stored is never mutable.

I have only added one benchmark to prove that it can be worth it to use a custom byte frequency table. Since the assembly for the actual search algorithm has not been changed, I think we just need a benchmark to prove the change does not cause a regression when constructing a search (already in the benchmark suite), and a benchmark to prove that the change can be beneficial (included in the pull request).

Finally, here are the commands I used for benchmarking:
To check for no regression:
Note: I tried to find the benchmark that spends the most time constructing a finder rather than searching since the search
algorithm has not been touched, only the code that constructs a `RareNeedleBytes` object.
```
cargo bench -- 'memmem/krate/oneshot/teeny-en/never-john-watson' --save-baseline master
cargo bench -- 'memmem/krate/oneshot/teeny-en/never-john-watson' --save-baseline freq
critcmp freq master
```
To check for improved throughput:
```
cargo bench -- 'memmem/krate/binary/*' --save-baseline bin
critcmp bin -g 'memmem/krate/binary/(\w+)'
```
I am new to open-source collaboration, so any feedback will be much appreciated.