### PR TITLE
Add compile time cpu feature detection when `no_std`

### DIFF
--- a/src/memchr/x86/mod.rs
+++ b/src/memchr/x86/mod.rs
@@ -2,7 +2,7 @@ use super::fallback;
 
 // We only use AVX when we can detect at runtime whether it's available, which
 // requires std.
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", all(memchr_runtime_avx, target_feature = "avx2")))]
 mod avx;
 mod sse2;
 
@@ -83,11 +83,12 @@ macro_rules! unsafe_ifunc {
 #[cfg(not(feature = "std"))]
 macro_rules! unsafe_ifunc {
     ($fnty:ty, $name:ident, $haystack:ident, $($needle:ident),+) => {{
-        if cfg!(memchr_runtime_sse2) {
-            unsafe { sse2::$name($($needle),+, $haystack) }
-        } else {
-            fallback::$name($($needle),+, $haystack)
-        }
+        #[cfg(all(memchr_runtime_avx, target_feature = "avx2"))]
+        unsafe { avx::$name($($needle),+, $haystack) }
+        #[cfg(all(memchr_runtime_sse2, not(all(memchr_runtime_avx, target_feature = "avx2"))))]
+        unsafe { sse2::$name($($needle),+, $haystack) }
+        #[cfg(all(not(memchr_runtime_sse2), not(memchr_runtime_avx), not(target_feature = "avx2")))]
+        fallback::$name($($needle),+, $haystack)
     }}
 }
 


### PR DESCRIPTION
Using `avx` instructions makes a big difference, being able to use them no-std would be cool. 
This PR attempts to add them by doing that feature detection at compile time if running `no_std`.  

The feature selection is a bit convoluted but it's supposed to be exclusive if I've got this right:
1. We only import `avx` on std, or if we've got `avx2` instructions.
2. We select `avx` on `no_std` if  we have `avx2` instructions.
3. We select `sse2` on `no_std` if we have `sse2` instructions but not `avx2` instructions.
4. We fallback on `no_std` if we don't have `avx2` or `sse2` instructions.

It's fairly difficult to tell if it's working, what I did was benchmark `std`, then I benchmarked with memchr `no-default-features`, then I benchmarked `RUSTFLAGS='-C target-cpu=native'` with `no-default-features` on a cpu that has `avx2`. 
The first and third bench was about on par, whereas the second had about half the throughput.

Edit: Woops, just saw https://github.com/BurntSushi/memchr/pull/106, but from reading the comments, this might be a good compromise.  
The use case is essentially micro optimization with dubious motivation.