### PR TITLE
crate: add 'alloc' feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,11 @@ jobs:
       name: Show byte order for debugging
       run: ${{ env.CARGO }} test --verbose $TARGET byte_order -- --nocapture
     - if: matrix.build != 'pinned'
+      name: Run tests under default configuration
       run: ${{ env.CARGO }} test --verbose $TARGET
+    - if: matrix.build != 'pinned'
+      name: Run tests with just alloc feature
+      run: ${{ env.CARGO }} test --verbose --no-default-features --features alloc $TARGET
     - if: matrix.build == 'stable'
       name: Run under different SIMD configurations
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,13 @@ default = ["std"]
 # permits this crate to use runtime CPU feature detection to automatically
 # accelerate searching via vector instructions. Without the standard library,
 # this automatic detection is not possible.
-std = []
+std = ["alloc"]
+
+# The 'alloc' feature enables some APIs that require allocation, such as
+# 'Finder::into_owned'. Note that this feature does not enable runtime CPU
+# feature detection. That still requires 'std'.
+alloc = []
+
 # The 'use_std' feature is DEPRECATED. It will be removed in memchr 3. Until
 # then, it is alias for the 'std' feature.
 use_std = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,9 @@ standard library exposes a platform independent SIMD API.
 )))]
 compile_error!("memchr currently not supported on non-{16,32,64}");
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 pub use crate::memchr::{
     memchr, memchr2, memchr2_iter, memchr3, memchr3_iter, memchr_iter,
     memrchr, memrchr2, memrchr2_iter, memrchr3, memrchr3_iter, memrchr_iter,

--- a/src/memmem/mod.rs
+++ b/src/memmem/mod.rs
@@ -332,8 +332,8 @@ impl<'h, 'n> FindIter<'h, 'n> {
     /// If this is already an owned iterator, then this is a no-op. Otherwise,
     /// this copies the needle.
     ///
-    /// This is only available when the `std` feature is enabled.
-    #[cfg(feature = "std")]
+    /// This is only available when the `alloc` feature is enabled.
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn into_owned(self) -> FindIter<'h, 'static> {
         FindIter {
@@ -526,8 +526,8 @@ impl<'n> Finder<'n> {
     /// If this is already an owned finder, then this is a no-op. Otherwise,
     /// this copies the needle.
     ///
-    /// This is only available when the `std` feature is enabled.
-    #[cfg(feature = "std")]
+    /// This is only available when the `alloc` feature is enabled.
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn into_owned(self) -> Finder<'static> {
         Finder { searcher: self.searcher.into_owned() }
@@ -921,7 +921,7 @@ impl<'n> Searcher<'n> {
         }
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn into_owned(self) -> Searcher<'static> {
         use self::SearcherKind::*;
 

--- a/src/memmem/x86/avx.rs
+++ b/src/memmem/x86/avx.rs
@@ -80,8 +80,8 @@ mod nostd {
 
     impl Forward {
         pub(crate) fn new(
-            ninfo: &NeedleInfo,
-            needle: &[u8],
+            _ninfo: &NeedleInfo,
+            _needle: &[u8],
         ) -> Option<Forward> {
             None
         }
@@ -92,8 +92,8 @@ mod nostd {
 
         pub(crate) fn find(
             &self,
-            haystack: &[u8],
-            needle: &[u8],
+            _haystack: &[u8],
+            _needle: &[u8],
         ) -> Option<usize> {
             unreachable!()
         }


### PR DESCRIPTION
This crate currently only has a 'std' feature and of course support for no-std. But in that mode, it was also no-alloc. In practice, this crate is virtually all core-only, that is, no-std and no-alloc. There are really only a few parts that want std or alloc. For std, runtime CPU feature detection requires it. For alloc, there are a few minor APIs that require allocation.

Previously, the only way to get the APIs that require allocation was to enable 'std'. This new feature permits getting those APIs without bringing in 'std'.

I don't expect this to unlock any new or interesting use cases, but it will make downstream configurations a little more sensible and less annoying.

Fixes #121