### PR TITLE
Update MSRV in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ as described above.
 
 ### Minimum Rust version policy
 
-This crate's minimum supported `rustc` version is `1.41.1`.
+This crate's minimum supported `rustc` version is `1.60.0`.
 
 The current policy is that the minimum Rust version required to use this crate
 can be increased in minor version updates. For example, if `crate 1.0` requires


### PR DESCRIPTION
The 2.6.0 release bumped the MSRV, but forgot to update the README to indicate that.