### PR TITLE
use `alloc` instead of `std` for `FinderRev::into_owned`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,26 +35,15 @@ memchr links to the standard library by default, but you can disable the
 memchr = { version = "2", default-features = false }
 ```
 
-On x86 platforms, when the `std` feature is disabled, the SSE2 accelerated
-implementations will be used. When `std` is enabled, AVX accelerated
+On `x86_64` platforms, when the `std` feature is disabled, the SSE2 accelerated
+implementations will be used. When `std` is enabled, AVX2 accelerated
 implementations will be used if the CPU is determined to support it at runtime.
 
-### Using libc
+SIMD accelerated routines are also available on the `wasm32` and `aarch64`
+targets. The `std` feature is not required to use them.
 
-`memchr` is a routine that is part of libc, although this crate does not use
-libc by default. Instead, it uses its own routines, which are either vectorized
-or generic fallback routines. In general, these should be competitive with
-what's in libc, although this has not been tested for all architectures. If
-using `memchr` from libc is desirable and a vectorized routine is not otherwise
-available in this crate, then enabling the `libc` feature will use libc's
-version of `memchr`.
-
-The rest of the functions in this crate, e.g., `memchr2` or `memrchr3` and the
-substring search routines, will always use the implementations in this crate.
-One exception to this is `memrchr`, which is an extension in `libc` found on
-Linux. On Linux, `memrchr` is used in precisely the same scenario as `memchr`,
-as described above.
-
+When a SIMD version is not available, then this crate falls back to
+[SWAR](https://en.wikipedia.org/wiki/SWAR) techniques.
 
 ### Minimum Rust version policy
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -4,29 +4,49 @@ version = 3
 
 [[package]]
 name = "arbitrary"
-version = "1.0.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "698b65a961a9d730fb45b6b0327e20207810c9f61ee421b082b27ba003f49e2b"
+checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "jobserver",
+ "libc",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.147"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.0"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86c975d637bc2a2f99440932b731491fc34c7f785d239e38af3addd3c2fd0e46"
+checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
 dependencies = [
  "arbitrary",
  "cc",
+ "once_cell",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.0"
 
 [[package]]
 name = "memchr-fuzz"
@@ -35,3 +55,9 @@ dependencies = [
  "libfuzzer-sys",
  "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"

--- a/src/memmem/mod.rs
+++ b/src/memmem/mod.rs
@@ -336,7 +336,7 @@ impl<'h, 'n> FindRevIter<'h, 'n> {
     /// this copies the needle.
     ///
     /// This is only available when the `std` feature is enabled.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn into_owned(self) -> FindRevIter<'h, 'static> {
         FindRevIter {
@@ -606,7 +606,7 @@ impl<'n> FinderRev<'n> {
     /// this copies the needle.
     ///
     /// This is only available when the `std` feature is enabled.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn into_owned(self) -> FinderRev<'static> {
         FinderRev {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -6,14 +6,10 @@ pub(crate) mod substring;
 
 // For debugging, particularly in CI, print out the byte order of the current
 // target.
-#[cfg(all(feature = "std", target_endian = "little"))]
 #[test]
 fn byte_order() {
+    #[cfg(target_endian = "little")]
     std::eprintln!("LITTLE ENDIAN");
-}
-
-#[cfg(all(feature = "std", target_endian = "big"))]
-#[test]
-fn byte_order() {
+    #[cfg(target_endian = "big")]
     std::eprintln!("BIG ENDIAN");
 }


### PR DESCRIPTION
This was an oversight in the 2.6 release. The forward case was marked as `alloc` (which was a new feature as of 2.6) but the reverse case was not.