### PR TITLE
unsafe impl Sync+Send

### DIFF
--- a/src/arch/generic/memchr.rs
+++ b/src/arch/generic/memchr.rs
@@ -1011,6 +1011,11 @@ pub(crate) struct Iter<'h> {
     haystack: core::marker::PhantomData<&'h [u8]>,
 }
 
+// SAFETY: `Iter` contains no shared references to anything that performs any interior mutations.
+unsafe impl Send for Iter<'_> {}
+// SAFETY: `Iter` perform no interior mutations, therefore no explicit synchronisation is necessary.
+unsafe impl Sync for Iter<'_> {}
+
 impl<'h> Iter<'h> {
     /// Create a new generic memchr iterator.
     #[inline(always)]

--- a/src/tests/memchr/mod.rs
+++ b/src/tests/memchr/mod.rs
@@ -305,3 +305,11 @@ impl Seed {
         more.into_iter()
     }
 }
+
+fn sync_regression() {
+    use crate::{Memchr, Memchr2, Memchr3};
+    fn assert_send_sync<T: Send + Send>() {}
+    assert_send_sync::<Memchr>();
+    assert_send_sync::<Memchr2>();
+    assert_send_sync::<Memchr3>()
+}


### PR DESCRIPTION
Fixes #133 

The pointers in `Iter` seem to be simply an optimization over using `&'h [u8]` which is Send+Sync. I couldn't find a more straightforward solution than just implementing Send+Sync on Iter.

If my safety comments aren't sufficient, I can improve them