### PR TITLE
arch: simplify and improve is_equal_raw

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # The version of wasmtime to download and install.
-      WASMTIME_VERSION: 12.0.1
+      WASMTIME_VERSION: 15.0.1
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -222,7 +222,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # The version of wasmtime to download and install.
-      WASMTIME_VERSION: 12.0.1
+      WASMTIME_VERSION: 15.0.1
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/benchmarks/engines.toml
+++ b/benchmarks/engines.toml
@@ -61,14 +61,14 @@
   [engine.version]
     bin = "wasmtime"
     args = [
-      "run", "--wasm-features", "simd", "--",
+      "run", "--wasm", "simd", "--",
       "./target/wasm32-wasi/release/main.wasm",
       "--version",
     ]
   [engine.run]
     bin = "wasmtime"
     args = [
-      "run", "--wasm-features", "simd", "--",
+      "run", "--wasm", "simd", "--",
       "./target/wasm32-wasi/release/main.wasm",
       "memchr-oneshot",
     ]
@@ -537,14 +537,14 @@
   [engine.version]
     bin = "wasmtime"
     args = [
-      "run", "--wasm-features", "simd", "--",
+      "run", "--wasm", "simd", "--",
       "./target/wasm32-wasi/release/main.wasm",
       "--version",
     ]
   [engine.run]
     bin = "wasmtime"
     args = [
-      "run", "--wasm-features", "simd", "--",
+      "run", "--wasm", "simd", "--",
       "./target/wasm32-wasi/release/main.wasm",
       "memchr-prebuilt",
     ]
@@ -569,14 +569,14 @@
   [engine.version]
     bin = "wasmtime"
     args = [
-      "run", "--wasm-features", "simd", "--",
+      "run", "--wasm", "simd", "--",
       "./target/wasm32-wasi/release/main.wasm",
       "--version",
     ]
   [engine.run]
     bin = "wasmtime"
     args = [
-      "run", "--wasm-features", "simd", "--",
+      "run", "--wasm", "simd", "--",
       "./target/wasm32-wasi/release/main.wasm",
       "memchr-onlycount",
     ]
@@ -601,14 +601,14 @@
   [engine.version]
     bin = "wasmtime"
     args = [
-      "run", "--wasm-features", "simd", "--",
+      "run", "--wasm", "simd", "--",
       "./target/wasm32-wasi/release/main.wasm",
       "--version",
     ]
   [engine.run]
     bin = "wasmtime"
     args = [
-      "run", "--wasm-features", "simd", "--",
+      "run", "--wasm", "simd", "--",
       "./target/wasm32-wasi/release/main.wasm",
       "memchr2",
     ]
@@ -633,14 +633,14 @@
   [engine.version]
     bin = "wasmtime"
     args = [
-      "run", "--wasm-features", "simd", "--",
+      "run", "--wasm", "simd", "--",
       "./target/wasm32-wasi/release/main.wasm",
       "--version",
     ]
   [engine.run]
     bin = "wasmtime"
     args = [
-      "run", "--wasm-features", "simd", "--",
+      "run", "--wasm", "simd", "--",
       "./target/wasm32-wasi/release/main.wasm",
       "memchr3",
     ]
@@ -665,14 +665,14 @@
   [engine.version]
     bin = "wasmtime"
     args = [
-      "run", "--wasm-features", "simd", "--",
+      "run", "--wasm", "simd", "--",
       "./target/wasm32-wasi/release/main.wasm",
       "--version",
     ]
   [engine.run]
     bin = "wasmtime"
     args = [
-      "run", "--wasm-features", "simd", "--",
+      "run", "--wasm", "simd", "--",
       "./target/wasm32-wasi/release/main.wasm",
       "memmem-prebuilt",
     ]

--- a/benchmarks/engines/libc/Cargo.toml
+++ b/benchmarks/engines/libc/Cargo.toml
@@ -19,3 +19,5 @@ path = "main.rs"
 
 [profile.release]
 debug = true
+codegen-units = 1
+lto = "fat"

--- a/benchmarks/engines/rust-bytecount/Cargo.lock
+++ b/benchmarks/engines/rust-bytecount/Cargo.lock
@@ -20,13 +20,13 @@ dependencies = [
 
 [[package]]
 name = "bytecount"
-version = "0.6.7"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
+checksum = "ad152d03a2c813c80bb94fedbf3a3f02b28f793e39e7c214c8a0bcc196343de7"
 
 [[package]]
 name = "main"
-version = "0.6.7"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "bytecount",

--- a/benchmarks/engines/rust-bytecount/Cargo.lock
+++ b/benchmarks/engines/rust-bytecount/Cargo.lock
@@ -20,13 +20,13 @@ dependencies = [
 
 [[package]]
 name = "bytecount"
-version = "0.6.3"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
 name = "main"
-version = "0.5.3"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "bytecount",

--- a/benchmarks/engines/rust-bytecount/Cargo.toml
+++ b/benchmarks/engines/rust-bytecount/Cargo.toml
@@ -1,14 +1,34 @@
 [package]
 publish = false
 name = "main"
-version = "0.6.7"
+version = "0.6.4"
 edition = "2021"
 
 [workspace]
 
 [dependencies]
 anyhow = "1.0.72"
-bytecount = "=0.6.7"
+# Note that with bytecount 0.6.7, it seems to fail on wasm32:
+#
+#     $ rebar measure -f '^memchr/sherlock/rare/huge1$' -e '^rust/bytecount/memchr/oneshot/wasm32$' -t
+#     Error: failed to run main module `./target/wasm32-wasi/release/main.wasm`
+#
+#     Caused by:
+#         0: failed to invoke command default
+#         1: error while executing at wasm backtrace:
+#                0: 0x7683 - <unknown>!bytecount::count::he2da8fc82662651b
+#                1: 0x4887 - <unknown>!main::main::he4a1bcea0da067f8
+#                2:  0x4fe - <unknown>!std::sys_common::backtrace::__rust_begin_short_backtrace::h3d2add2c8c259792
+#                3: 0x7f2f - <unknown>!__main_void
+#                4:  0x4d9 - <unknown>!_start
+#            note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable may show more debugging information
+#         2: memory fault at wasm address 0x3a0000 in linear memory of size 0x3a0000
+#         3: wasm trap: out of bounds memory access
+#     memchr/sherlock/rare/huge1,count-bytes,rust/bytecount/memchr/oneshot/wasm32,0.6.7,failed to run command for 'rust/bytecount/memchr/oneshot/wasm32'
+#     some benchmarks failed
+#
+# It's not clear what's happening here, but 0.6.4 works.
+bytecount = "=0.6.4"
 
 [dependencies.shared]
 path = "../../shared"

--- a/benchmarks/engines/rust-bytecount/Cargo.toml
+++ b/benchmarks/engines/rust-bytecount/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 publish = false
 name = "main"
-version = "0.5.3"
+version = "0.6.7"
 edition = "2021"
 
 [workspace]
 
 [dependencies]
 anyhow = "1.0.72"
-bytecount = "=0.6.3"
+bytecount = "=0.6.7"
 
 [dependencies.shared]
 path = "../../shared"
@@ -19,3 +19,5 @@ path = "main.rs"
 
 [profile.release]
 debug = true
+codegen-units = 1
+lto = "fat"

--- a/benchmarks/engines/rust-jetscii/Cargo.toml
+++ b/benchmarks/engines/rust-jetscii/Cargo.toml
@@ -19,3 +19,5 @@ path = "main.rs"
 
 [profile.release]
 debug = true
+codegen-units = 1
+lto = "fat"

--- a/benchmarks/engines/rust-memchr/Cargo.lock
+++ b/benchmarks/engines/rust-memchr/Cargo.lock
@@ -14,24 +14,28 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
- "memchr",
+ "memchr 2.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
 ]
 
 [[package]]
 name = "main"
-version = "2.6.1"
+version = "2.6.4"
 dependencies = [
  "anyhow",
- "memchr",
+ "memchr 2.6.4",
  "shared",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.6.1"
+version = "2.6.4"
+
+[[package]]
+name = "memchr"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f478948fd84d9f8e86967bf432640e46adfb5a4bd4f14ef7e864ab38220534ae"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "serde"

--- a/benchmarks/engines/rust-memchr/Cargo.toml
+++ b/benchmarks/engines/rust-memchr/Cargo.toml
@@ -1,18 +1,14 @@
 [package]
 publish = false
 name = "main"
-version = "2.6.1"  # should match 'memchr' version below
+version = "2.6.4"  # should match current 'memchr' version
 edition = "2021"
 
 [workspace]
 
-# Uncomment to benchmark changes.
-# [patch.crates-io]
-# memchr = { path = "../../../" }
-
 [dependencies]
 anyhow = "1.0.72"
-memchr = "=2.6.1"
+memchr = { version = "*", path = "../../../" }
 
 [dependencies.shared]
 path = "../../shared"
@@ -23,3 +19,5 @@ path = "main.rs"
 
 [profile.release]
 debug = true
+codegen-units = 1
+lto = "fat"

--- a/benchmarks/engines/rust-memchrold/Cargo.toml
+++ b/benchmarks/engines/rust-memchrold/Cargo.toml
@@ -19,3 +19,5 @@ path = "main.rs"
 
 [profile.release]
 debug = true
+codegen-units = 1
+lto = "fat"

--- a/benchmarks/engines/rust-sliceslice/Cargo.lock
+++ b/benchmarks/engines/rust-sliceslice/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "main"
-version = "2.5.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "shared",

--- a/benchmarks/engines/rust-sliceslice/Cargo.toml
+++ b/benchmarks/engines/rust-sliceslice/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "main"
-version = "2.5.0"  # should match 'memchr' version below
+version = "0.4.1"  # should match 'sliceslice' version below
 edition = "2021"
 
 [workspace]
@@ -19,3 +19,5 @@ path = "main.rs"
 
 [profile.release]
 debug = true
+codegen-units = 1
+lto = "fat"

--- a/benchmarks/engines/rust-std/Cargo.toml
+++ b/benchmarks/engines/rust-std/Cargo.toml
@@ -21,3 +21,5 @@ path = "main.rs"
 
 [profile.release]
 debug = true
+codegen-units = 1
+lto = "fat"


### PR DESCRIPTION
This came from [@jhorstmann in #139][jhorstmann-is-equal]. It
simplifies `is_equal_raw` and also in turn simplifies its codegen.
Since this routine gets inlined into others, this winds up being a fair
improvement:

    $ rebar diff -e memchr/memmem tmp/base.csv tmp/simpler-is-equal-raw.csv -t 1.1
    benchmark                                          engine                       tmp/base.csv       tmp/simpler-is-equal-raw.csv
    ---------                                          ------                       ------------       ----------------------------
    memmem/code/rust-library-never-fn-strength         rust/memchr/memmem/prebuilt  40.6 GB/s (1.24x)  50.2 GB/s (1.00x)
    memmem/code/rust-library-never-fn-strength-paren   rust/memchr/memmem/prebuilt  39.4 GB/s (1.30x)  51.3 GB/s (1.00x)
    memmem/code/rust-library-never-fn-quux             rust/memchr/memmem/prebuilt  41.0 GB/s (1.25x)  51.4 GB/s (1.00x)
    memmem/code/rust-library-rare-fn-from-str          rust/memchr/memmem/prebuilt  38.8 GB/s (1.35x)  52.4 GB/s (1.00x)
    memmem/code/rust-library-common-fn-is-empty        rust/memchr/memmem/prebuilt  40.2 GB/s (1.25x)  50.3 GB/s (1.00x)
    memmem/code/rust-library-common-fn                 rust/memchr/memmem/prebuilt  24.7 GB/s (1.18x)  29.2 GB/s (1.00x)
    memmem/code/rust-library-common-let                rust/memchr/memmem/prebuilt  18.1 GB/s (1.10x)  20.0 GB/s (1.00x)
    memmem/pathological/md5-huge-no-hash               rust/memchr/memmem/prebuilt  38.5 GB/s (1.30x)  50.0 GB/s (1.00x)
    memmem/pathological/md5-huge-last-hash             rust/memchr/memmem/prebuilt  38.0 GB/s (1.32x)  50.1 GB/s (1.00x)
    memmem/pathological/rare-repeated-huge-tricky      rust/memchr/memmem/prebuilt  36.6 GB/s (1.72x)  62.8 GB/s (1.00x)
    memmem/pathological/defeat-simple-vector-alphabet  rust/memchr/memmem/prebuilt  4.0 GB/s (1.33x)   5.4 GB/s (1.00x)
    memmem/sliceslice/seemingly-random                 rust/memchr/memmem/prebuilt  8.1 MB/s (1.17x)   9.5 MB/s (1.00x)
    memmem/sliceslice/i386                             rust/memchr/memmem/prebuilt  42.7 MB/s (1.25x)  53.5 MB/s (1.00x)
    memmem/subtitles/common/huge-en-that               rust/memchr/memmem/prebuilt  30.7 GB/s (1.22x)  37.4 GB/s (1.00x)
    memmem/subtitles/common/huge-ru-that               rust/memchr/memmem/prebuilt  28.8 GB/s (1.26x)  36.2 GB/s (1.00x)
    memmem/subtitles/common/huge-ru-one-space          rust/memchr/memmem/prebuilt  2.6 GB/s (1.00x)   2.3 GB/s (1.12x)
    memmem/subtitles/common/huge-zh-that               rust/memchr/memmem/prebuilt  27.2 GB/s (1.40x)  38.2 GB/s (1.00x)
    memmem/subtitles/common/huge-zh-do-not             rust/memchr/memmem/prebuilt  18.0 GB/s (1.14x)  20.4 GB/s (1.00x)
    memmem/subtitles/never/huge-en-john-watson         rust/memchr/memmem/prebuilt  39.8 GB/s (1.55x)  61.6 GB/s (1.00x)
    memmem/subtitles/never/huge-en-all-common-bytes    rust/memchr/memmem/prebuilt  41.1 GB/s (1.25x)  51.4 GB/s (1.00x)
    memmem/subtitles/never/huge-en-some-rare-bytes     rust/memchr/memmem/prebuilt  40.2 GB/s (1.57x)  63.0 GB/s (1.00x)
    memmem/subtitles/never/huge-en-two-space           rust/memchr/memmem/prebuilt  33.2 GB/s (1.89x)  62.8 GB/s (1.00x)
    memmem/subtitles/never/huge-ru-john-watson         rust/memchr/memmem/prebuilt  39.2 GB/s (1.61x)  63.1 GB/s (1.00x)
    memmem/subtitles/never/huge-zh-john-watson         rust/memchr/memmem/prebuilt  39.6 GB/s (1.43x)  56.6 GB/s (1.00x)
    memmem/subtitles/rare/huge-en-sherlock-holmes      rust/memchr/memmem/prebuilt  39.3 GB/s (1.55x)  61.0 GB/s (1.00x)
    memmem/subtitles/rare/huge-en-sherlock             rust/memchr/memmem/prebuilt  43.5 GB/s (1.25x)  54.2 GB/s (1.00x)
    memmem/subtitles/rare/huge-en-medium-needle        rust/memchr/memmem/prebuilt  32.9 GB/s (1.60x)  52.7 GB/s (1.00x)
    memmem/subtitles/rare/huge-ru-sherlock-holmes      rust/memchr/memmem/prebuilt  38.7 GB/s (1.58x)  61.0 GB/s (1.00x)
    memmem/subtitles/rare/huge-ru-sherlock             rust/memchr/memmem/prebuilt  39.5 GB/s (1.51x)  59.4 GB/s (1.00x)
    memmem/subtitles/rare/huge-zh-sherlock-holmes      rust/memchr/memmem/prebuilt  35.9 GB/s (1.29x)  46.3 GB/s (1.00x)
    memmem/subtitles/rare/huge-zh-sherlock             rust/memchr/memmem/prebuilt  35.5 GB/s (1.56x)  55.1 GB/s (1.00x)

See my commentary in #139 for more discussion.

Fixes #139

[jhorstmann-is-equal]: https://github.com/BurntSushi/memchr/issues/139#issuecomment-1813187898