### PR TITLE
Remove obsolete exclusions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/BurntSushi/memchr"
 readme = "README.md"
 keywords = ["memchr", "memmem", "substring", "find", "search"]
 license = "Unlicense OR MIT"
-exclude = ["/bench", "/benchmarks", "/.github", "/fuzz", "/scripts", "/tmp"]
+exclude = ["/.github", "/benchmarks", "/fuzz", "/scripts"]
 edition = "2021"
 rust-version = "1.61"
 


### PR DESCRIPTION
I no longer see any bench or tmp directories in the repo.