### PR TITLE
tests: fix compiling tests with beta and nightly

### DIFF
--- a/src/tests/memchr/prop.rs
+++ b/src/tests/memchr/prop.rs
@@ -1,11 +1,13 @@
 #[cfg(miri)]
 #[macro_export]
+#[allow(missing_docs)]
 macro_rules! define_memchr_quickcheck {
     ($($tt:tt)*) => {};
 }
 
 #[cfg(not(miri))]
 #[macro_export]
+#[allow(missing_docs)]
 macro_rules! define_memchr_quickcheck {
     ($mod:ident) => {
         define_memchr_quickcheck!($mod, new);


### PR DESCRIPTION
CI is [failing](https://github.com/BurntSushi/memchr/actions) because memchr enables `missing_docs` lint but some exported macros in tests are not documented.

```console
cargo +nightly test                                                                                                        [Husky.local][11/18 21:26]
   Compiling memchr v2.7.4 (/Users/rhysd/Develop/github.com/BurntSushi/memchr)
error: missing documentation for a macro
   --> src/tests/memchr/prop.rs:9:1
    |
9   | macro_rules! define_memchr_quickcheck {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
note: the lint level is defined here
   --> src/lib.rs:172:9
    |
172 | #![deny(missing_docs)]
    |         ^^^^^^^^^^^^

error: could not compile `memchr` (lib test) due to 1 previous error
```

This PR fixes the compile errors by allowing missing docs on the macros.