### PR TITLE
WIP: add support for AVX512

### DIFF
--- a/src/arch/generic/memchr.rs
+++ b/src/arch/generic/memchr.rs
@@ -92,7 +92,7 @@ Generic crate-internal routines for the `memchr` family of functions.
 
 use crate::{
     ext::Pointer,
-    vector::{MoveMask, Vector},
+    vector::{ComparisonVector, MoveMask, Vector},
 };
 
 /// Finds all occurrences of a single byte in a haystack.
@@ -149,7 +149,7 @@ impl<V: Vector> One<V> {
         // need to move up to using a u64 for the masks used below. Currently
         // they are 32 bits, which means we're SOL for vectors that need masks
         // bigger than 32 bits. Overall unclear until there's a use case.
-        debug_assert!(V::BYTES <= 32, "vector cannot be bigger than 32 bytes");
+        debug_assert!(V::BYTES <= 64, "vector cannot be bigger than 64 bytes");
 
         let topos = V::Mask::first_offset;
         let len = end.distance(start);

--- a/src/arch/generic/packedpair.rs
+++ b/src/arch/generic/packedpair.rs
@@ -11,7 +11,7 @@ frequencies to heuristically select the pair of bytes to search for.
 use crate::{
     arch::all::{is_equal_raw, packedpair::Pair},
     ext::Pointer,
-    vector::{MoveMask, Vector},
+    vector::{ComparisonVector, MoveMask, Vector},
 };
 
 /// A generic architecture dependent "packed pair" finder.

--- a/src/arch/x86_64/avx2/packedpair.rs
+++ b/src/arch/x86_64/avx2/packedpair.rs
@@ -8,7 +8,7 @@ frequencies to heuristically select the pair of bytes to search for.
 [generic SIMD]: http://0x80.pl/articles/simd-strfind.html#first-and-last
 */
 
-use core::arch::x86_64::{__m128i, __m256i};
+use core::arch::x86_64::{__m128i, __m256i, __m512i};
 
 use crate::arch::{all::packedpair::Pair, generic::packedpair};
 
@@ -23,6 +23,7 @@ use crate::arch::{all::packedpair::Pair, generic::packedpair};
 pub struct Finder {
     sse2: packedpair::Finder<__m128i>,
     avx2: packedpair::Finder<__m256i>,
+    avx512: packedpair::Finder<__m512i>,
 }
 
 impl Finder {
@@ -68,7 +69,8 @@ impl Finder {
     unsafe fn with_pair_impl(needle: &[u8], pair: Pair) -> Finder {
         let sse2 = packedpair::Finder::<__m128i>::new(needle, pair);
         let avx2 = packedpair::Finder::<__m256i>::new(needle, pair);
-        Finder { sse2, avx2 }
+        let avx512 = packedpair::Finder::<__m512i>::new(needle, pair);
+        Finder { sse2, avx2, avx512 }
     }
 
     /// Returns true when this implementation is available in the current
@@ -107,6 +109,8 @@ impl Finder {
                 }
             }
         }
+
+        // TODO: avx512
     }
 
     /// Execute a search using AVX2 vectors and routines.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(stdarch_x86_avx512)]
+
 /*!
 This library provides heavily optimized routines for string search primitives.
 

--- a/src/tests/memchr/prop.rs
+++ b/src/tests/memchr/prop.rs
@@ -4,6 +4,8 @@ macro_rules! define_memchr_quickcheck {
     ($($tt:tt)*) => {};
 }
 
+/// TODO: add comment
+
 #[cfg(not(miri))]
 #[macro_export]
 macro_rules! define_memchr_quickcheck {


### PR DESCRIPTION
First of all: I would like to thank you for the library!

I was just curious how difficult it would be to add support for AVX 512 vector types,  thus I made a proof-of-concept PR. The biggest complication for AVX512 comes from the fact the [cmp_eq function](https://doc.rust-lang.org/beta/core/arch/x86/fn._mm512_cmp_epi8_mask.html) has `u64` as a return type. That's a difference from `__m128i` and `__m256i` types, where the return type is a mask in the corresponding victory type. That's why the change would need a split of `Vector` trait into 2: `Vector` and `ComparisonVector`.

Anyway, the question is if you'll be interested in the full support?