### PR TITLE
Remove `compiler-builtins` from `rustc-dep-of-std` dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ libc = []
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
-rustc-dep-of-std = ['core', 'compiler_builtins']
+rustc-dep-of-std = ['core']
 
 [dependencies]
 # Only used when the `logging` feature is enabled (disabled by default).
@@ -60,7 +60,6 @@ log = { version = "0.4.20", optional = true }
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
 core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
-compiler_builtins = { version = '0.1.2', optional = true }
 
 [dev-dependencies]
 quickcheck = { version = "1.0.3", default-features = false }


### PR DESCRIPTION
Since [1], this will come automatically from `rustc-std-workspace-core` and the crates.io dependency should no longer be specified.

[1]: https://github.com/rust-lang/rust/pull/141993