### PR TITLE
memmem: add owned finder constructor variants

### DIFF
--- a/src/cow.rs
+++ b/src/cow.rs
@@ -43,7 +43,9 @@ impl<'a> CowBytes<'a> {
     /// Create a new owned CowBytes.
     #[cfg(feature = "alloc")]
     #[inline(always)]
-    fn new_owned(bytes: alloc::boxed::Box<[u8]>) -> CowBytes<'static> {
+    pub(crate) fn new_owned(
+        bytes: alloc::boxed::Box<[u8]>,
+    ) -> CowBytes<'static> {
         CowBytes(Imp::Owned(bytes))
     }
 


### PR DESCRIPTION
I wasn't sure how to call the new constructors so fell back to just suffixing already existing ones with `_owned`.

Note that I haven't added the `From<Box<[u8]>>` (and related) convenient helpers since they are not strictly required and I would like to land the minimal required change first.

Fixes #173