### PR TITLE
ci: build docs.rs for more architectures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,3 +76,4 @@ debug = true
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--generate-link-to-definition"]
+targets = ["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "powerpc64-unknown-linux-gnu", "s390x-unknown-linux-gnu", "wasm32-wasip1"]


### PR DESCRIPTION
Currently, there isn't an option to see the exported modules for aarch64 in `memchr::arch` for example. Let's fix that.