### PR TITLE
Fix NEON optimization on big-endian aarch64

### DIFF
--- a/src/arch/aarch64/neon/packedpair.rs
+++ b/src/arch/aarch64/neon/packedpair.rs
@@ -52,7 +52,7 @@ impl Finder {
     #[inline]
     pub fn with_pair(needle: &[u8], pair: Pair) -> Option<Finder> {
         if Finder::is_available() {
-            // SAFETY: we check that sse2 is available above. We are also
+            // SAFETY: we check that NEON is available above. We are also
             // guaranteed to have needle.len() > 1 because we have a valid
             // Pair.
             unsafe { Some(Finder::with_pair_impl(needle, pair)) }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -376,18 +376,10 @@ mod aarch64neon {
     impl NeonMoveMask {
         /// Get the mask in a form suitable for computing offsets.
         ///
-        /// Basically, this normalizes to little endian. On big endian, this
-        /// swaps the bytes.
+        /// The mask is always already in host-endianness, so this is a no-op.
         #[inline(always)]
         fn get_for_offset(self) -> u64 {
-            #[cfg(target_endian = "big")]
-            {
-                self.0.swap_bytes()
-            }
-            #[cfg(target_endian = "little")]
-            {
-                self.0
-            }
+            self.0
         }
     }
 


### PR DESCRIPTION
I'm not completely aware how the code works, but I've tested this fix on aarch64_be. Previously, `memchr` produced many wrong results, but with this fix it's good.

aarch64 (little-endian) and other big-endian architectures should be unaffected.

This bugfix is necessary in order to build a working rustc, standard library and cargo.