### PR TITLE
Avoid redudant mask computations in the generic Two and Three implementations.

### DIFF
--- a/src/arch/generic/memchr.rs
+++ b/src/arch/generic/memchr.rs
@@ -528,16 +528,16 @@ impl<V: Vector> Two<V> {
                 let eqb1 = self.v1.cmpeq(b);
                 let eqa2 = self.v2.cmpeq(a);
                 let eqb2 = self.v2.cmpeq(b);
-                let or1 = eqa1.or(eqb1);
-                let or2 = eqa2.or(eqb2);
+                let or1 = eqa1.or(eqa2);
+                let or2 = eqb1.or(eqb2);
                 let or3 = or1.or(or2);
                 if or3.movemask_will_have_non_zero() {
-                    let mask = eqa1.movemask().or(eqa2.movemask());
+                    let mask = or1.movemask();
                     if mask.has_non_zero() {
                         return Some(cur.add(topos(mask)));
                     }
 
-                    let mask = eqb1.movemask().or(eqb2.movemask());
+                    let mask = or2.movemask();
                     debug_assert!(mask.has_non_zero());
                     return Some(cur.add(V::BYTES).add(topos(mask)));
                 }
@@ -625,16 +625,16 @@ impl<V: Vector> Two<V> {
                 let eqb1 = self.v1.cmpeq(b);
                 let eqa2 = self.v2.cmpeq(a);
                 let eqb2 = self.v2.cmpeq(b);
-                let or1 = eqa1.or(eqb1);
-                let or2 = eqa2.or(eqb2);
+                let or1 = eqa1.or(eqa2);
+                let or2 = eqb1.or(eqb2);
                 let or3 = or1.or(or2);
                 if or3.movemask_will_have_non_zero() {
-                    let mask = eqb1.movemask().or(eqb2.movemask());
+                    let mask = or2.movemask();
                     if mask.has_non_zero() {
                         return Some(cur.add(V::BYTES).add(topos(mask)));
                     }
 
-                    let mask = eqa1.movemask().or(eqa2.movemask());
+                    let mask = or1.movemask();
                     debug_assert!(mask.has_non_zero());
                     return Some(cur.add(topos(mask)));
                 }
@@ -677,9 +677,7 @@ impl<V: Vector> Two<V> {
         let eq2 = self.v2.cmpeq(chunk);
         let mask = eq1.or(eq2).movemask();
         if mask.has_non_zero() {
-            let mask1 = eq1.movemask();
-            let mask2 = eq2.movemask();
-            Some(cur.add(mask_to_offset(mask1.or(mask2))))
+            Some(cur.add(mask_to_offset(mask)))
         } else {
             None
         }
@@ -802,24 +800,18 @@ impl<V: Vector> Three<V> {
                 let eqb2 = self.v2.cmpeq(b);
                 let eqa3 = self.v3.cmpeq(a);
                 let eqb3 = self.v3.cmpeq(b);
-                let or1 = eqa1.or(eqb1);
-                let or2 = eqa2.or(eqb2);
-                let or3 = eqa3.or(eqb3);
-                let or4 = or1.or(or2);
+                let or1 = eqa1.or(eqa2);
+                let or2 = eqb1.or(eqb2);
+                let or3 = or1.or(eqa3);
+                let or4 = or2.or(eqb3);
                 let or5 = or3.or(or4);
                 if or5.movemask_will_have_non_zero() {
-                    let mask = eqa1
-                        .movemask()
-                        .or(eqa2.movemask())
-                        .or(eqa3.movemask());
+                    let mask = or3.movemask();
                     if mask.has_non_zero() {
                         return Some(cur.add(topos(mask)));
                     }
 
-                    let mask = eqb1
-                        .movemask()
-                        .or(eqb2.movemask())
-                        .or(eqb3.movemask());
+                    let mask = or4.movemask();
                     debug_assert!(mask.has_non_zero());
                     return Some(cur.add(V::BYTES).add(topos(mask)));
                 }
@@ -909,24 +901,18 @@ impl<V: Vector> Three<V> {
                 let eqb2 = self.v2.cmpeq(b);
                 let eqa3 = self.v3.cmpeq(a);
                 let eqb3 = self.v3.cmpeq(b);
-                let or1 = eqa1.or(eqb1);
-                let or2 = eqa2.or(eqb2);
-                let or3 = eqa3.or(eqb3);
-                let or4 = or1.or(or2);
+                let or1 = eqa1.or(eqa2);
+                let or2 = eqb1.or(eqb2);
+                let or3 = or1.or(eqa3);
+                let or4 = or2.or(eqb3);
                 let or5 = or3.or(or4);
                 if or5.movemask_will_have_non_zero() {
-                    let mask = eqb1
-                        .movemask()
-                        .or(eqb2.movemask())
-                        .or(eqb3.movemask());
+                    let mask = or4.movemask();
                     if mask.has_non_zero() {
                         return Some(cur.add(V::BYTES).add(topos(mask)));
                     }
 
-                    let mask = eqa1
-                        .movemask()
-                        .or(eqa2.movemask())
-                        .or(eqa3.movemask());
+                    let mask = or3.movemask();
                     debug_assert!(mask.has_non_zero());
                     return Some(cur.add(topos(mask)));
                 }
@@ -970,10 +956,7 @@ impl<V: Vector> Three<V> {
         let eq3 = self.v3.cmpeq(chunk);
         let mask = eq1.or(eq2).or(eq3).movemask();
         if mask.has_non_zero() {
-            let mask1 = eq1.movemask();
-            let mask2 = eq2.movemask();
-            let mask3 = eq3.movemask();
-            Some(cur.add(mask_to_offset(mask1.or(mask2).or(mask3))))
+            Some(cur.add(mask_to_offset(mask)))
         } else {
             None
         }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -93,9 +93,6 @@ pub(crate) trait MoveMask: Copy + core::fmt::Debug {
     /// Does a bitwise `and` operation between `self` and `other`.
     fn and(self, other: Self) -> Self;
 
-    /// Does a bitwise `or` operation between `self` and `other`.
-    fn or(self, other: Self) -> Self;
-
     /// Returns a mask that is equivalent to `self` but with the least
     /// significant 1-bit set to 0.
     fn clear_least_significant_bit(self) -> Self;
@@ -155,11 +152,6 @@ impl MoveMask for SensibleMoveMask {
     #[inline(always)]
     fn and(self, other: SensibleMoveMask) -> SensibleMoveMask {
         SensibleMoveMask(self.0 & other.0)
-    }
-
-    #[inline(always)]
-    fn or(self, other: SensibleMoveMask) -> SensibleMoveMask {
-        SensibleMoveMask(self.0 | other.0)
     }
 
     #[inline(always)]
@@ -403,11 +395,6 @@ mod aarch64neon {
         #[inline(always)]
         fn and(self, other: NeonMoveMask) -> NeonMoveMask {
             NeonMoveMask(self.0 & other.0)
-        }
-
-        #[inline(always)]
-        fn or(self, other: NeonMoveMask) -> NeonMoveMask {
-            NeonMoveMask(self.0 | other.0)
         }
 
         #[inline(always)]


### PR DESCRIPTION
This does not appear to make a difference in the `rust/memchr/memchr(2|3)$` benchmarks running on x86-64 with AVX2. I would argue that it does make for simpler code though.

I suspect there is a reason for this structure and did dig through the Git history but could not find anything. (I ended up at the big "rewrite everything" commit.) At least on x86-64, I would expect fewer "movemask" instructions to be preferable due to their high latency? 