### PR TITLE
Hint to the compiler that returned indices are in-bounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.61.0
+        toolchain: 1.81.0
     - name: Basic build
       run: cargo build --verbose
     - name: Build docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["memchr", "memmem", "substring", "find", "search"]
 license = "Unlicense OR MIT"
 exclude = ["/.github", "/benchmarks", "/fuzz", "/scripts", "/tmp"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.81"
 
 [lib]
 name = "memchr"


### PR DESCRIPTION
Closes #195

With this change, this function in a downstream crate:
```rust
pub fn foo(x: &[u8], y: u8) -> &[u8] {
    match memchr::memchr(y, x) {
        Some(i) => &x[i..],
        None => &[],
    }
}
```

Generates this assembly:
<details>
<summary><b>Assembly output</b></summary>

```asm
foobar::foo:
	push r14
	push rbx
	push rax
	mov eax, edx
	mov rbx, rsi
	mov r14, rdi
	lea rdx, [rdi + rsi]
	mov rcx, qword ptr [rip + memchr::arch::x86_64::memchr::memchr_raw::FN@GOTPCREL]
	mov rcx, qword ptr [rcx]
	mov edi, eax
	mov rsi, r14
	call rcx
	mov rcx, rax
	test cl, 1
	je .LBB0_1
	mov rax, rdx
	sub r14, rdx
	add rbx, r14
	jmp .LBB0_2
.LBB0_1:
	mov eax, 1
	xor ebx, ebx
.LBB0_2:
	mov rdx, rbx
	add rsp, 8
	pop rbx
	pop r14
	ret
```
</details>

Whereas before, it would include a branch to `core::slice::index::slice_index_fail`.

This only works for the oneshot functions, not `memchr_iter`, since `Iter` doesn't hold a reference to the original slice. To get the same effect there, I think you'd have to add a `original_len: usize` field to `Iter`, which isn't that crazy but maybe seems silly to only use it for an optimization hint.