### PR TITLE
Fix clippy question_mark

### DIFF
--- a/src/memmem/mod.rs
+++ b/src/memmem/mod.rs
@@ -351,10 +351,7 @@ impl<'h, 'n> Iterator for FindRevIter<'h, 'n> {
     type Item = usize;
 
     fn next(&mut self) -> Option<usize> {
-        let pos = match self.pos {
-            None => return None,
-            Some(pos) => pos,
-        };
+        let pos = self.pos?;
         let result = self.finder.rfind(&self.haystack[..pos]);
         match result {
             None => None,


### PR DESCRIPTION
This fixes [question_mark](https://rust-lang.github.io/rust-clippy/master/index.html#question_mark).