### PR TITLE
lint: fix clippy doc_lazy_continuation

### DIFF
--- a/src/arch/all/memchr.rs
+++ b/src/arch/all/memchr.rs
@@ -113,13 +113,13 @@ impl One {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `None` will always be returned.
@@ -183,13 +183,13 @@ impl One {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `None` will always be returned.
@@ -242,13 +242,13 @@ impl One {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `0` will always be returned.
@@ -423,13 +423,13 @@ impl Two {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `None` will always be returned.
@@ -489,13 +489,13 @@ impl Two {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `None` will always be returned.
@@ -687,13 +687,13 @@ impl Three {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `None` will always be returned.
@@ -753,13 +753,13 @@ impl Three {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `None` will always be returned.

--- a/src/arch/all/mod.rs
+++ b/src/arch/all/mod.rs
@@ -95,15 +95,15 @@ pub fn is_equal(x: &[u8], y: &[u8]) -> bool {
 /// * Both `x` and `y` must be valid for reads of up to `n` bytes.
 /// * Both `x` and `y` must point to an initialized value.
 /// * Both `x` and `y` must each point to an allocated object and
-/// must either be in bounds or at most one byte past the end of the
-/// allocated object. `x` and `y` do not need to point to the same allocated
-/// object, but they may.
+///   must either be in bounds or at most one byte past the end of the
+///   allocated object. `x` and `y` do not need to point to the same allocated
+///   object, but they may.
 /// * Both `x` and `y` must be _derived from_ a pointer to their respective
-/// allocated objects.
+///   allocated objects.
 /// * The distance between `x` and `x+n` must not overflow `isize`. Similarly
-/// for `y` and `y+n`.
+///   for `y` and `y+n`.
 /// * The distance being in bounds must not rely on "wrapping around" the
-/// address space.
+///   address space.
 #[inline(always)]
 pub unsafe fn is_equal_raw(
     mut x: *const u8,

--- a/src/arch/all/rabinkarp.rs
+++ b/src/arch/all/rabinkarp.rs
@@ -138,13 +138,13 @@ impl Finder {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     /// * It must be the case that `start <= end`.
     #[inline]
     pub unsafe fn find_raw(
@@ -236,13 +236,13 @@ impl FinderRev {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     /// * It must be the case that `start <= end`.
     #[inline]
     pub unsafe fn rfind_raw(

--- a/src/arch/all/twoway.rs
+++ b/src/arch/all/twoway.rs
@@ -69,10 +69,10 @@ pub struct FinderRev(TwoWay);
 ///
 /// 1. Do something to detect a "critical" position in the needle.
 /// 2. For the current position in the haystack, look if `needle[critical..]`
-/// matches at that position.
+///    matches at that position.
 /// 3. If so, look if `needle[..critical]` matches.
 /// 4. If a mismatch occurs, shift the search by some amount based on the
-/// critical position and a pre-computed shift.
+///    critical position and a pre-computed shift.
 ///
 /// This type is wrapped in the forward and reverse finders that expose
 /// consistent forward or reverse APIs.

--- a/src/arch/generic/memchr.rs
+++ b/src/arch/generic/memchr.rs
@@ -127,18 +127,18 @@ impl<V: Vector> One<V> {
     /// # Safety
     ///
     /// * It must be the case that `start < end` and that the distance between
-    /// them is at least equal to `V::BYTES`. That is, it must always be valid
-    /// to do at least an unaligned load of `V` at `start`.
+    ///   them is at least equal to `V::BYTES`. That is, it must always be valid
+    ///   to do at least an unaligned load of `V` at `start`.
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     #[inline(always)]
     pub(crate) unsafe fn find_raw(
         &self,
@@ -238,18 +238,18 @@ impl<V: Vector> One<V> {
     /// # Safety
     ///
     /// * It must be the case that `start < end` and that the distance between
-    /// them is at least equal to `V::BYTES`. That is, it must always be valid
-    /// to do at least an unaligned load of `V` at `start`.
+    ///   them is at least equal to `V::BYTES`. That is, it must always be valid
+    ///   to do at least an unaligned load of `V` at `start`.
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     #[inline(always)]
     pub(crate) unsafe fn rfind_raw(
         &self,
@@ -333,18 +333,18 @@ impl<V: Vector> One<V> {
     /// # Safety
     ///
     /// * It must be the case that `start < end` and that the distance between
-    /// them is at least equal to `V::BYTES`. That is, it must always be valid
-    /// to do at least an unaligned load of `V` at `start`.
+    ///   them is at least equal to `V::BYTES`. That is, it must always be valid
+    ///   to do at least an unaligned load of `V` at `start`.
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     #[inline(always)]
     pub(crate) unsafe fn count_raw(
         &self,
@@ -477,18 +477,18 @@ impl<V: Vector> Two<V> {
     /// # Safety
     ///
     /// * It must be the case that `start < end` and that the distance between
-    /// them is at least equal to `V::BYTES`. That is, it must always be valid
-    /// to do at least an unaligned load of `V` at `start`.
+    ///   them is at least equal to `V::BYTES`. That is, it must always be valid
+    ///   to do at least an unaligned load of `V` at `start`.
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     #[inline(always)]
     pub(crate) unsafe fn find_raw(
         &self,
@@ -576,18 +576,18 @@ impl<V: Vector> Two<V> {
     /// # Safety
     ///
     /// * It must be the case that `start < end` and that the distance between
-    /// them is at least equal to `V::BYTES`. That is, it must always be valid
-    /// to do at least an unaligned load of `V` at `start`.
+    ///   them is at least equal to `V::BYTES`. That is, it must always be valid
+    ///   to do at least an unaligned load of `V` at `start`.
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     #[inline(always)]
     pub(crate) unsafe fn rfind_raw(
         &self,
@@ -749,18 +749,18 @@ impl<V: Vector> Three<V> {
     /// # Safety
     ///
     /// * It must be the case that `start < end` and that the distance between
-    /// them is at least equal to `V::BYTES`. That is, it must always be valid
-    /// to do at least an unaligned load of `V` at `start`.
+    ///   them is at least equal to `V::BYTES`. That is, it must always be valid
+    ///   to do at least an unaligned load of `V` at `start`.
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     #[inline(always)]
     pub(crate) unsafe fn find_raw(
         &self,
@@ -858,18 +858,18 @@ impl<V: Vector> Three<V> {
     /// # Safety
     ///
     /// * It must be the case that `start < end` and that the distance between
-    /// them is at least equal to `V::BYTES`. That is, it must always be valid
-    /// to do at least an unaligned load of `V` at `start`.
+    ///   them is at least equal to `V::BYTES`. That is, it must always be valid
+    ///   to do at least an unaligned load of `V` at `start`.
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     #[inline(always)]
     pub(crate) unsafe fn rfind_raw(
         &self,

--- a/src/arch/x86_64/avx2/memchr.rs
+++ b/src/arch/x86_64/avx2/memchr.rs
@@ -165,13 +165,13 @@ impl One {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `None` will always be returned.
@@ -231,13 +231,13 @@ impl One {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `None` will always be returned.
@@ -285,13 +285,13 @@ impl One {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `0` will always be returned.
@@ -640,13 +640,13 @@ impl Two {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `None` will always be returned.
@@ -706,13 +706,13 @@ impl Two {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `None` will always be returned.
@@ -1023,13 +1023,13 @@ impl Three {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `None` will always be returned.
@@ -1091,13 +1091,13 @@ impl Three {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `None` will always be returned.

--- a/src/arch/x86_64/sse2/memchr.rs
+++ b/src/arch/x86_64/sse2/memchr.rs
@@ -142,13 +142,13 @@ impl One {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `None` will always be returned.
@@ -198,13 +198,13 @@ impl One {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `None` will always be returned.
@@ -243,13 +243,13 @@ impl One {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `0` will always be returned.
@@ -506,13 +506,13 @@ impl Two {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `None` will always be returned.
@@ -562,13 +562,13 @@ impl Two {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `None` will always be returned.
@@ -807,13 +807,13 @@ impl Three {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `None` will always be returned.
@@ -865,13 +865,13 @@ impl Three {
     /// * Both `start` and `end` must be valid for reads.
     /// * Both `start` and `end` must point to an initialized value.
     /// * Both `start` and `end` must point to the same allocated object and
-    /// must either be in bounds or at most one byte past the end of the
-    /// allocated object.
+    ///   must either be in bounds or at most one byte past the end of the
+    ///   allocated object.
     /// * Both `start` and `end` must be _derived from_ a pointer to the same
-    /// object.
+    ///   object.
     /// * The distance between `start` and `end` must not overflow `isize`.
     /// * The distance being in bounds must not rely on "wrapping around" the
-    /// address space.
+    ///   address space.
     ///
     /// Note that callers may pass a pair of pointers such that `start >= end`.
     /// In that case, `None` will always be returned.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,36 +137,36 @@ accelerated implementations of `memchr` (and friends) and `memmem`.
 # Crate features
 
 * **std** - When enabled (the default), this will permit features specific to
-the standard library. Currently, the only thing used from the standard library
-is runtime SIMD CPU feature detection. This means that this feature must be
-enabled to get AVX2 accelerated routines on `x86_64` targets without enabling
-the `avx2` feature at compile time, for example. When `std` is not enabled,
-this crate will still attempt to use SSE2 accelerated routines on `x86_64`. It
-will also use AVX2 accelerated routines when the `avx2` feature is enabled at
-compile time. In general, enable this feature if you can.
+  the standard library. Currently, the only thing used from the standard library
+  is runtime SIMD CPU feature detection. This means that this feature must be
+  enabled to get AVX2 accelerated routines on `x86_64` targets without enabling
+  the `avx2` feature at compile time, for example. When `std` is not enabled,
+  this crate will still attempt to use SSE2 accelerated routines on `x86_64`. It
+  will also use AVX2 accelerated routines when the `avx2` feature is enabled at
+  compile time. In general, enable this feature if you can.
 * **alloc** - When enabled (the default), APIs in this crate requiring some
-kind of allocation will become available. For example, the
-[`memmem::Finder::into_owned`](crate::memmem::Finder::into_owned) API and the
-[`arch::all::shiftor`](crate::arch::all::shiftor) substring search
-implementation. Otherwise, this crate is designed from the ground up to be
-usable in core-only contexts, so the `alloc` feature doesn't add much
-currently. Notably, disabling `std` but enabling `alloc` will **not** result
-in the use of AVX2 on `x86_64` targets unless the `avx2` feature is enabled
-at compile time. (With `std` enabled, AVX2 can be used even without the `avx2`
-feature enabled at compile time by way of runtime CPU feature detection.)
-* **logging** - When enabled (disabled by default), the `log` crate is used
-to emit log messages about what kinds of `memchr` and `memmem` algorithms
-are used. Namely, both `memchr` and `memmem` have a number of different
-implementation choices depending on the target and CPU, and the log messages
-can help show what specific implementations are being used. Generally, this is
-useful for debugging performance issues.
+  kind of allocation will become available. For example, the
+  [`memmem::Finder::into_owned`](crate::memmem::Finder::into_owned) API and the
+  [`arch::all::shiftor`](crate::arch::all::shiftor) substring search
+  implementation. Otherwise, this crate is designed from the ground up to be
+  usable in core-only contexts, so the `alloc` feature doesn't add much
+  currently. Notably, disabling `std` but enabling `alloc` will **not** result
+  in the use of AVX2 on `x86_64` targets unless the `avx2` feature is enabled
+  at compile time. (With `std` enabled, AVX2 can be used even without the `avx2`
+  feature enabled at compile time by way of runtime CPU feature detection.)
+  * **logging** - When enabled (disabled by default), the `log` crate is used
+    to emit log messages about what kinds of `memchr` and `memmem` algorithms
+    are used. Namely, both `memchr` and `memmem` have a number of different
+    implementation choices depending on the target and CPU, and the log messages
+    can help show what specific implementations are being used. Generally, this
+    is useful for debugging performance issues.
 * **libc** - **DEPRECATED**. Previously, this enabled the use of the target's
-`memchr` function from whatever `libc` was linked into the program. This
-feature is now a no-op because this crate's implementation of `memchr` should
-now be sufficiently fast on a number of platforms that `libc` should no longer
-be needed. (This feature is somewhat of a holdover from this crate's origins.
-Originally, this crate was literally just a safe wrapper function around the
-`memchr` function from `libc`.)
+    `memchr` function from whatever `libc` was linked into the program. This
+    feature is now a no-op because this crate's implementation of `memchr`
+    should now be sufficiently fast on a number of platforms that `libc` should
+    no longer be needed. (This feature is somewhat of a holdover from this
+    crate's origins. Originally, this crate was literally just a safe wrapper
+    function around the `memchr` function from `libc`.)
 */
 
 #![deny(missing_docs)]


### PR DESCRIPTION
This fixes [doc_lazy_continuation](https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation).

Lines were reflowed as needed.