### PR TITLE
lint: allow identity_op

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,3 +76,6 @@ debug = true
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--generate-link-to-definition"]
+
+[lints.clippy]
+identity_op = "allow"


### PR DESCRIPTION
This adds a `lints.clippy` section to Cargo.toml, which should be supported by Rust 1.74+ and ignored by older versions.

This is related to #199.