### PR TITLE
lint: fix clippy get_first

### DIFF
--- a/src/arch/all/rabinkarp.rs
+++ b/src/arch/all/rabinkarp.rs
@@ -86,7 +86,7 @@ impl Finder {
     #[inline]
     pub fn new(needle: &[u8]) -> Finder {
         let mut s = Finder { hash: Hash::new(), hash_2pow: 1 };
-        let first_byte = match needle.get(0) {
+        let first_byte = match needle.first() {
             None => return s,
             Some(&first_byte) => first_byte,
         };

--- a/src/arch/all/twoway.rs
+++ b/src/arch/all/twoway.rs
@@ -323,7 +323,7 @@ impl FinderRev {
         let nlen = needle.len();
         let mut pos = haystack.len();
         let mut shift = nlen;
-        let first_byte = match needle.get(0) {
+        let first_byte = match needle.first() {
             None => return Some(pos),
             Some(&first_byte) => first_byte,
         };
@@ -364,7 +364,7 @@ impl FinderRev {
     ) -> Option<usize> {
         let nlen = needle.len();
         let mut pos = haystack.len();
-        let first_byte = match needle.get(0) {
+        let first_byte = match needle.first() {
             None => return Some(pos),
             Some(&first_byte) => first_byte,
         };


### PR DESCRIPTION
This fixes [get_first](https://rust-lang.github.io/rust-clippy/master/index.html#get_first).

This is another style lint. Feel free to close if you prefer `get(0)`.