### PR TITLE
[POC] feat: memchr-n

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -38,6 +38,12 @@ test = false
 doc = false
 
 [[bin]]
+name = "memchrn"
+path = "fuzz_targets/memchrn.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "memrchr"
 path = "fuzz_targets/memrchr.rs"
 test = false

--- a/fuzz/fuzz_targets/memchrn.rs
+++ b/fuzz/fuzz_targets/memchrn.rs
@@ -1,0 +1,24 @@
+#![no_main]
+
+use std::collections::HashSet;
+
+use libfuzzer_sys::fuzz_target;
+use memchr::memchrn_iter;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 8 {
+        return;
+    }
+    let needles = &data[..8];
+    let haystack = &data[8..];
+
+    let unique_needles =
+        needles.into_iter().map(|v| *v).collect::<HashSet<_>>();
+    if unique_needles.len() != needles.len() {
+        return;
+    }
+
+    let cnt1 = memchrn_iter(&needles, haystack).count();
+    let cnt2 = haystack.iter().filter(|c| needles.contains(c)).count();
+    assert_eq!(cnt1, cnt2);
+});

--- a/src/arch/aarch64/memchr.rs
+++ b/src/arch/aarch64/memchr.rs
@@ -135,3 +135,18 @@ pub(crate) unsafe fn count_raw(
 ) -> usize {
     defraw!(One, count_raw, start, end, n1)
 }
+
+#[inline(always)]
+pub(crate) unsafe fn memchrn_raw(
+    raw: *const u8,
+    raw_len: usize,
+    low_tab: *const u8,
+    high_tab: *const u8,
+    mask: u8,
+    start: *const u8,
+    end: *const u8,
+) -> Option<*const u8> {
+    defraw!(
+        Multiple, find_raw, start, end, raw, raw_len, low_tab, high_tab, mask
+    )
+}

--- a/src/arch/aarch64/neon/memchr.rs
+++ b/src/arch/aarch64/neon/memchr.rs
@@ -952,6 +952,88 @@ impl<'a, 'h> DoubleEndedIterator for ThreeIter<'a, 'h> {
 
 impl<'a, 'h> core::iter::FusedIterator for ThreeIter<'a, 'h> {}
 
+/// Hi
+#[derive(Clone, Debug)]
+pub struct Multiple<'raw>(&'raw [u8], generic::Multiple<uint8x16_t>);
+
+impl<'raw> Multiple<'raw> {
+    /// Safety:
+    ///     1. size of low_tab, high_tab must be 16
+    ///     2. len must be exact the size of bytes
+    #[inline]
+    pub fn new_unchecked(
+        bytes: *const u8,
+        len: usize,
+        low_tab: *const u8,
+        high_tab: *const u8,
+        mask: u8,
+    ) -> Self {
+        unsafe {
+            let raw = core::mem::transmute((bytes, len));
+            let lo = uint8x16_t::load_aligned(low_tab);
+            let hi = uint8x16_t::load_aligned(high_tab);
+            Self(raw, generic::Multiple::new(lo, hi, mask))
+        }
+    }
+
+    /// Hi
+    #[inline]
+    pub fn is_available() -> bool {
+        #[cfg(target_feature = "neon")]
+        {
+            true
+        }
+        #[cfg(not(target_feature = "neon"))]
+        {
+            false
+        }
+    }
+
+    /// Hi
+    #[inline]
+    pub fn find(&self, haystack: &[u8]) -> Option<usize> {
+        // SAFETY: `find_raw` guarantees that if a pointer is returned, it
+        // falls within the bounds of the start and end pointers.
+        unsafe {
+            generic::search_slice_with_raw(haystack, |s, e| {
+                self.find_raw(s, e)
+            })
+        }
+    }
+
+    /// Hi
+    #[inline]
+    pub unsafe fn find_raw(
+        &self,
+        start: *const u8,
+        end: *const u8,
+    ) -> Option<*const u8> {
+        if start >= end {
+            return None;
+        }
+        if end.distance(start) < uint8x16_t::BYTES {
+            // SAFETY: We require the caller to pass valid start/end pointers.
+            return generic::fwd_byte_by_byte(start, end, |b| {
+                self.0.iter().any(|c| *c == b)
+            });
+        }
+        // SAFETY: Building a `Three` means it's safe to call 'neon' routines.
+        // Also, we've checked that our haystack is big enough to run on the
+        // vector routine. Pointer validity is caller's responsibility.
+        self.find_raw_impl(start, end)
+    }
+
+    #[target_feature(enable = "neon")]
+    #[inline]
+    unsafe fn find_raw_impl(
+        &self,
+        start: *const u8,
+        end: *const u8,
+    ) -> Option<*const u8> {
+        self.1.find_raw(start, end)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1027,5 +1109,11 @@ mod tests {
                 Some(Three::new(n1, n2, n3)?.iter(haystack).rev().collect())
             },
         )
+    }
+
+    #[test]
+    fn test_multiple() {
+        let s = "12345678".repeat(8);
+        // Multiple::new(bytes, low_tab, high_tab, mask)
     }
 }

--- a/src/arch/all/memchr.rs
+++ b/src/arch/all/memchr.rs
@@ -867,6 +867,84 @@ impl<'a, 'h> DoubleEndedIterator for ThreeIter<'a, 'h> {
     }
 }
 
+/// HI
+#[derive(Clone, Debug)]
+pub struct Multiple {
+    raw: alloc::vec::Vec<u8>,
+    splat: alloc::vec::Vec<usize>,
+}
+
+impl Multiple {
+    /// Hi
+    pub fn new(
+        bytes: *const u8,
+        len: usize,
+        _low_tab: *const u8,
+        _high_tab: *const u8,
+        _mask: u8,
+    ) -> Self {
+        let slice: &[u8] = unsafe { core::mem::transmute((bytes, len)) };
+        let raw = slice.to_vec();
+        let splat =
+            slice.iter().map(|v| splat(*v)).collect::<alloc::vec::Vec<_>>();
+        Self { raw, splat }
+    }
+
+    /// Hi
+    #[inline]
+    pub unsafe fn find_raw(
+        &self,
+        start: *const u8,
+        end: *const u8,
+    ) -> Option<*const u8> {
+        if start >= end {
+            return None;
+        }
+        let confirm = |b| self.confirm(b);
+        let len = end.distance(start);
+        if len < USIZE_BYTES {
+            return generic::fwd_byte_by_byte(start, end, confirm);
+        }
+
+        // The start of the search may not be aligned to `*const usize`,
+        // so we do an unaligned load here.
+        let chunk = start.cast::<usize>().read_unaligned();
+        if self.has_needle(chunk) {
+            return generic::fwd_byte_by_byte(start, end, confirm);
+        }
+
+        // And now we start our search at a guaranteed aligned position.
+        // The first iteration of the loop below will overlap with the
+        // unaligned chunk above in cases where the search starts at an
+        // unaligned offset, but that's okay as we're only here if that
+        // above didn't find a match.
+        let mut cur =
+            start.add(USIZE_BYTES - (start.as_usize() & USIZE_ALIGN));
+        debug_assert!(cur > start);
+        debug_assert!(end.sub(USIZE_BYTES) >= start);
+        while cur <= end.sub(USIZE_BYTES) {
+            debug_assert_eq!(0, cur.as_usize() % USIZE_BYTES);
+
+            let chunk = cur.cast::<usize>().read();
+            if self.has_needle(chunk) {
+                break;
+            }
+            cur = cur.add(USIZE_BYTES);
+        }
+        generic::fwd_byte_by_byte(cur, end, confirm)
+    }
+
+    #[inline(always)]
+    fn has_needle(&self, chunk: usize) -> bool {
+        self.splat.iter().any(|v| *v ^ chunk != 0)
+    }
+
+    #[inline(always)]
+    fn confirm(&self, haystack_byte: u8) -> bool {
+        self.raw.iter().any(|s| *s == haystack_byte)
+    }
+}
+
 /// Return `true` if `x` contains any zero byte.
 ///
 /// That is, this routine treats `x` as a register of 8-bit lanes and returns

--- a/src/arch/generic/memchr.rs
+++ b/src/arch/generic/memchr.rs
@@ -1212,3 +1212,64 @@ pub(crate) unsafe fn count_byte_by_byte<F: Fn(u8) -> bool>(
     }
     count
 }
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Multiple<V> {
+    lo: V,
+    hi: V,
+    mask: u8,
+}
+
+impl<V: Vector> Multiple<V> {
+    pub(crate) unsafe fn new(lo: V, hi: V, mask: u8) -> Self {
+        Self { lo, hi, mask }
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn find_raw(
+        &self,
+        start: *const u8,
+        end: *const u8,
+    ) -> Option<*const u8> {
+        let mut cur = start;
+        while cur <= end.sub(V::BYTES) {
+            let chunk = V::load_unaligned(cur);
+            if let Some(m) = self.find_one(chunk) {
+                return Some(cur.add(m));
+            }
+            cur = cur.add(V::BYTES);
+        }
+        if cur < end {
+            let chunk = V::load_unaligned(end.sub(V::BYTES));
+            if let Some(m) = self.find_one(chunk) {
+                return Some(end.sub(V::BYTES - m));
+            }
+        }
+        None
+    }
+
+    unsafe fn find_one(&self, chunk: V) -> Option<usize> {
+        let res = self.bitmask(chunk);
+        let mask = res.movemask();
+        if mask.has_non_zero() {
+            Some(mask.first_offset())
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn bitmask(&self, chunk: V) -> V {
+        let mask = V::splat(self.mask);
+        let lomask = V::splat(0xF);
+        let hlo = chunk.and(lomask);
+        let hhi = chunk.shift_8bit_lane_right::<4>().and(lomask);
+        let locand = self.lo.shuffle_bytes(hlo);
+        let hicand = self.hi.shuffle_bytes(hhi);
+        let loc = locand.and(hicand);
+        // loc & mask != 0
+        let res = loc.and(mask).cmpneq(V::splat(0x00));
+
+        res
+    }
+}

--- a/src/arch/x86_64/avx2/memchr.rs
+++ b/src/arch/x86_64/avx2/memchr.rs
@@ -1273,6 +1273,88 @@ impl<'a, 'h> DoubleEndedIterator for ThreeIter<'a, 'h> {
 
 impl<'a, 'h> core::iter::FusedIterator for ThreeIter<'a, 'h> {}
 
+/// Hi
+#[derive(Clone, Debug)]
+pub struct Multiple<'raw>(&'raw [u8], generic::Multiple<__m128i>);
+
+impl<'raw> Multiple<'raw> {
+    /// Safety:
+    ///     1. size of low_tab, high_tab must be 16
+    ///     2. len must be exact the size of bytes
+    #[inline]
+    pub fn new_unchecked(
+        bytes: *const u8,
+        len: usize,
+        low_tab: *const u8,
+        high_tab: *const u8,
+        mask: u8,
+    ) -> Self {
+        unsafe {
+            let raw = core::mem::transmute((bytes, len));
+            let lo = __m128i::load_unaligned(low_tab);
+            let hi = __m128i::load_unaligned(high_tab);
+            Self(raw, generic::Multiple::new(lo, hi, mask))
+        }
+    }
+
+    /// Hi
+    #[inline]
+    pub fn is_available() -> bool {
+        #[cfg(target_feature = "avx2")]
+        {
+            true
+        }
+        #[cfg(not(target_feature = "avx2"))]
+        {
+            false
+        }
+    }
+
+    /// Hi
+    #[inline]
+    pub fn find(&self, haystack: &[u8]) -> Option<usize> {
+        // SAFETY: `find_raw` guarantees that if a pointer is returned, it
+        // falls within the bounds of the start and end pointers.
+        unsafe {
+            generic::search_slice_with_raw(haystack, |s, e| {
+                self.find_raw(s, e)
+            })
+        }
+    }
+
+    /// Hi
+    #[inline]
+    pub unsafe fn find_raw(
+        &self,
+        start: *const u8,
+        end: *const u8,
+    ) -> Option<*const u8> {
+        if start >= end {
+            return None;
+        }
+        if end.distance(start) < __m128i::BYTES {
+            // SAFETY: We require the caller to pass valid start/end pointers.
+            return generic::fwd_byte_by_byte(start, end, |b| {
+                self.0.iter().any(|c| *c == b)
+            });
+        }
+        // SAFETY: Building a `Three` means it's safe to call 'neon' routines.
+        // Also, we've checked that our haystack is big enough to run on the
+        // vector routine. Pointer validity is caller's responsibility.
+        self.find_raw_impl(start, end)
+    }
+
+    #[target_feature(enable = "avx2")]
+    #[inline]
+    unsafe fn find_raw_impl(
+        &self,
+        start: *const u8,
+        end: *const u8,
+    ) -> Option<*const u8> {
+        self.1.find_raw(start, end)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/arch/x86_64/memchr.rs
+++ b/src/arch/x86_64/memchr.rs
@@ -63,7 +63,7 @@ macro_rules! unsafe_ifunc {
         $retty:ty,
         $hay_start:ident,
         $hay_end:ident,
-        $($needle:ident),+
+        $($needle:ident : $nty:ty),+
     ) => {{
         #![allow(unused_unsafe)]
 
@@ -76,7 +76,7 @@ macro_rules! unsafe_ifunc {
         #[cfg(target_feature = "sse2")]
         #[target_feature(enable = "sse2", enable = "avx2")]
         unsafe fn find_avx2(
-            $($needle: u8),+,
+            $($needle: $nty),+,
             $hay_start: *const u8,
             $hay_end: *const u8,
         ) -> $retty {
@@ -88,7 +88,7 @@ macro_rules! unsafe_ifunc {
         #[cfg(target_feature = "sse2")]
         #[target_feature(enable = "sse2")]
         unsafe fn find_sse2(
-            $($needle: u8),+,
+            $($needle: $nty),+,
             $hay_start: *const u8,
             $hay_end: *const u8,
         ) -> $retty {
@@ -98,7 +98,7 @@ macro_rules! unsafe_ifunc {
         }
 
         unsafe fn find_fallback(
-            $($needle: u8),+,
+            $($needle: $nty),+,
             $hay_start: *const u8,
             $hay_end: *const u8,
         ) -> $retty {
@@ -107,7 +107,7 @@ macro_rules! unsafe_ifunc {
         }
 
         unsafe fn detect(
-            $($needle: u8),+,
+            $($needle: $nty),+,
             $hay_start: *const u8,
             $hay_end: *const u8,
         ) -> $retty {
@@ -184,7 +184,7 @@ pub(crate) fn memchr_raw(
         Option<*const u8>,
         start,
         end,
-        n1
+        n1: u8
     )
 }
 
@@ -207,7 +207,7 @@ pub(crate) fn memrchr_raw(
         Option<*const u8>,
         start,
         end,
-        n1
+        n1: u8
     )
 }
 
@@ -231,8 +231,8 @@ pub(crate) fn memchr2_raw(
         Option<*const u8>,
         start,
         end,
-        n1,
-        n2
+        n1: u8,
+        n2: u8
     )
 }
 
@@ -256,8 +256,8 @@ pub(crate) fn memrchr2_raw(
         Option<*const u8>,
         start,
         end,
-        n1,
-        n2
+        n1: u8,
+        n2: u8
     )
 }
 
@@ -282,9 +282,9 @@ pub(crate) fn memchr3_raw(
         Option<*const u8>,
         start,
         end,
-        n1,
-        n2,
-        n3
+        n1: u8,
+        n2: u8,
+        n3: u8
     )
 }
 
@@ -309,9 +309,43 @@ pub(crate) fn memrchr3_raw(
         Option<*const u8>,
         start,
         end,
-        n1,
-        n2,
-        n3
+        n1: u8,
+        n2: u8,
+        n3: u8
+    )
+}
+
+#[inline(always)]
+pub(crate) fn memchrn_raw(
+    raw: *const u8,
+    raw_len: usize,
+    low_tab: *const u8,
+    high_tab: *const u8,
+    mask: u8,
+    start: *const u8,
+    end: *const u8,
+) -> Option<*const u8> {
+    // SAFETY: We provide a valid function pointer type.
+    unsafe_ifunc!(
+        Multiple,
+        find_raw,
+        unsafe fn(
+            *const u8,
+            usize,
+            *const u8,
+            *const u8,
+            u8,
+            *const u8,
+            *const u8,
+        ) -> Option<*const u8>,
+        Option<*const u8>,
+        start,
+        end,
+        raw: *const u8,
+        raw_len: usize,
+        low_tab: *const u8,
+        high_tab: *const u8,
+        mask: u8
     )
 }
 
@@ -330,6 +364,6 @@ pub(crate) fn count_raw(n1: u8, start: *const u8, end: *const u8) -> usize {
         usize,
         start,
         end,
-        n1
+        n1: u8
     )
 }

--- a/src/arch/x86_64/sse2/memchr.rs
+++ b/src/arch/x86_64/sse2/memchr.rs
@@ -998,6 +998,88 @@ impl<'a, 'h> DoubleEndedIterator for ThreeIter<'a, 'h> {
 
 impl<'a, 'h> core::iter::FusedIterator for ThreeIter<'a, 'h> {}
 
+/// Hi
+#[derive(Clone, Debug)]
+pub struct Multiple<'raw>(&'raw [u8], generic::Multiple<__m128i>);
+
+impl<'raw> Multiple<'raw> {
+    /// Safety:
+    ///     1. size of low_tab, high_tab must be 16
+    ///     2. len must be exact the size of bytes
+    #[inline]
+    pub fn new_unchecked(
+        bytes: *const u8,
+        len: usize,
+        low_tab: *const u8,
+        high_tab: *const u8,
+        mask: u8,
+    ) -> Self {
+        unsafe {
+            let raw = core::mem::transmute((bytes, len));
+            let lo = __m128i::load_unaligned(low_tab);
+            let hi = __m128i::load_unaligned(high_tab);
+            Self(raw, generic::Multiple::new(lo, hi, mask))
+        }
+    }
+
+    /// Hi
+    #[inline]
+    pub fn is_available() -> bool {
+        #[cfg(target_feature = "sse2")]
+        {
+            true
+        }
+        #[cfg(not(target_feature = "sse2"))]
+        {
+            false
+        }
+    }
+
+    /// Hi
+    #[inline]
+    pub fn find(&self, haystack: &[u8]) -> Option<usize> {
+        // SAFETY: `find_raw` guarantees that if a pointer is returned, it
+        // falls within the bounds of the start and end pointers.
+        unsafe {
+            generic::search_slice_with_raw(haystack, |s, e| {
+                self.find_raw(s, e)
+            })
+        }
+    }
+
+    /// Hi
+    #[inline]
+    pub unsafe fn find_raw(
+        &self,
+        start: *const u8,
+        end: *const u8,
+    ) -> Option<*const u8> {
+        if start >= end {
+            return None;
+        }
+        if end.distance(start) < __m128i::BYTES {
+            // SAFETY: We require the caller to pass valid start/end pointers.
+            return generic::fwd_byte_by_byte(start, end, |b| {
+                self.0.iter().any(|c| *c == b)
+            });
+        }
+        // SAFETY: Building a `Three` means it's safe to call 'neon' routines.
+        // Also, we've checked that our haystack is big enough to run on the
+        // vector routine. Pointer validity is caller's responsibility.
+        self.find_raw_impl(start, end)
+    }
+
+    #[target_feature(enable = "avx2")]
+    #[inline]
+    unsafe fn find_raw_impl(
+        &self,
+        start: *const u8,
+        end: *const u8,
+    ) -> Option<*const u8> {
+        self.1.find_raw(start, end)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,8 +202,8 @@ extern crate alloc;
 
 pub use crate::memchr::{
     memchr, memchr2, memchr2_iter, memchr3, memchr3_iter, memchr_iter,
-    memrchr, memrchr2, memrchr2_iter, memrchr3, memrchr3_iter, memrchr_iter,
-    Memchr, Memchr2, Memchr3,
+    memchrn_iter, memrchr, memrchr2, memrchr2_iter, memrchr3, memrchr3_iter,
+    memrchr_iter, Memchr, Memchr2, Memchr3, MemchrN,
 };
 
 #[macro_use]

--- a/src/memchr.rs
+++ b/src/memchr.rs
@@ -274,6 +274,16 @@ pub fn memrchr3_iter(
     Memchr3::new(needle1, needle2, needle3, haystack).rev()
 }
 
+/// Returns an iterator over all occurrences of the needles in a haystack, in
+/// reverse.
+#[inline]
+pub fn memchrn_iter<'n, 'h>(
+    needles: &'n [u8],
+    haystack: &'h [u8],
+) -> MemchrN<'n, 'h> {
+    MultiByteFinder::new(needles).unwrap().iter(haystack)
+}
+
 /// An iterator over all occurrences of a single byte in a haystack.
 ///
 /// This iterator implements `DoubleEndedIterator`, which means it can also be
@@ -750,6 +760,194 @@ unsafe fn count_raw(needle: u8, start: *const u8, end: *const u8) -> usize {
     }
 }
 
+pub struct MultiByteFinder<'n> {
+    needles: &'n [u8],
+    low_tab: [u8; 16],
+    high_tab: [u8; 16],
+    bit_mask: u8,
+}
+
+impl<'n> MultiByteFinder<'n> {
+    pub fn new(needles: &'n [u8]) -> Result<Self, ()> {
+        if needles.len() <= 8 {
+            Ok(Self::build_impl_fast(needles))
+        } else {
+            Self::build_impl_slow(needles)
+        }
+    }
+
+    fn build_impl_fast(needles: &'n [u8]) -> Self {
+        // TODO: add uniqueness check
+        assert!(needles.len() <= 8);
+        let mut low_tab = [0u8; 16];
+        let mut high_tab = [0u8; 16];
+
+        for (i, &byte) in needles.iter().enumerate() {
+            let bit = 1u8 << i;
+            low_tab[(byte & 0x0f) as usize] |= bit;
+            high_tab[(byte >> 4) as usize] |= bit;
+        }
+
+        let bit_mask = (1u32 << needles.len()).wrapping_sub(1) as u8;
+        Self { needles, low_tab, high_tab, bit_mask }
+    }
+
+    fn build_impl_slow(needles: &'n [u8]) -> Result<Self, ()> {
+        /// for a bit(bucket), suppose there are chars [s1, s2, s3]
+        /// we have the low parts and high parts:
+        ///     [s1_low, s2_low, s3_low]
+        ///     [s1_high, s2_high, s3_high]
+        /// we have to make sure: for any c = high<<4 + s1_low, c must belongs to this bucket
+        /// in other words, if it's well-formed after adding candidate to the `bit_index`,
+        /// then it's ok to do so.
+        fn is_safe(
+            bit_index: u8,
+            candidate: u8,
+            targets: &[u8],
+            current_low: &[u8; 16],
+            current_high: &[u8; 16],
+        ) -> bool {
+            let c_hi = (candidate >> 4) as usize;
+            let c_lo = (candidate & 0x0F) as usize;
+            let bit = 1 << bit_index;
+
+            for other_hi in 0..16 {
+                for other_lo in 0..16 {
+                    if (current_high[other_hi] & bit != 0)
+                        && (current_low[other_lo] & bit != 0)
+                    {
+                        let ghost1 = ((c_hi << 4) | other_lo) as u8;
+                        let ghost2 = ((other_hi << 4) | c_lo) as u8;
+
+                        if !targets.contains(&ghost1)
+                            || !targets.contains(&ghost2)
+                        {
+                            return false;
+                        }
+                    }
+                }
+            }
+            true
+        }
+
+        let mut low_tab = [0u8; 16];
+        let mut high_tab = [0u8; 16];
+        let mut current_bit = 0;
+        let mut bit_mask = 0u8;
+
+        for &c in needles {
+            if current_bit >= 8 {
+                return Err(());
+            }
+
+            let hi = (c >> 4) as usize;
+            let lo = (c & 0x0F) as usize;
+
+            let mut placed = false;
+            for b in 0..current_bit {
+                if is_safe(b, c, needles, &low_tab, &high_tab) {
+                    low_tab[lo] |= 1 << b;
+                    high_tab[hi] |= 1 << b;
+                    placed = true;
+                    break;
+                }
+            }
+
+            if !placed && current_bit < 8 {
+                low_tab[lo] |= 1 << current_bit;
+                high_tab[hi] |= 1 << current_bit;
+                bit_mask |= 1 << current_bit;
+                current_bit += 1;
+            }
+        }
+        Ok(Self { needles, low_tab, high_tab, bit_mask })
+    }
+
+    pub fn iter<'h>(&self, haystack: &'h [u8]) -> MemchrN<'n, 'h> {
+        MemchrN {
+            needles: self.needles,
+            low_tab: self.low_tab,
+            high_tab: self.high_tab,
+            bit_mask: self.bit_mask,
+            it: crate::arch::generic::memchr::Iter::new(haystack),
+        }
+    }
+}
+
+/// Hi
+pub struct MemchrN<'n, 'h> {
+    needles: &'n [u8],
+    low_tab: [u8; 16],
+    high_tab: [u8; 16],
+    bit_mask: u8,
+    it: crate::arch::generic::memchr::Iter<'h>,
+}
+
+#[inline]
+unsafe fn memchrn_raw(
+    raw: *const u8,
+    raw_len: usize,
+    low_tab: *const u8,
+    high_tab: *const u8,
+    mask: u8,
+    start: *const u8,
+    end: *const u8,
+) -> Option<*const u8> {
+    #[cfg(target_arch = "x86_64")]
+    {
+        crate::arch::x86_64::memchr::memchrn_raw(
+            raw, raw_len, low_tab, high_tab, mask, start, end,
+        )
+    }
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    {
+        todo!()
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        crate::arch::aarch64::memchr::memchrn_raw(
+            raw, raw_len, low_tab, high_tab, mask, start, end,
+        )
+    }
+    #[cfg(not(any(
+        target_arch = "x86_64",
+        all(target_arch = "wasm32", target_feature = "simd128"),
+        target_arch = "aarch64"
+    )))]
+    {
+        todo!()
+    }
+}
+
+impl<'n, 'h> Iterator for MemchrN<'n, 'h> {
+    type Item = usize;
+
+    #[inline]
+    fn next(&mut self) -> Option<usize> {
+        // SAFETY: All of our implementations of memchr ensure that any
+        // pointers returns will fall within the start and end bounds, and this
+        // upholds the safety contract of `self.it.next`.
+        unsafe {
+            self.it.next(|s, e| {
+                memchrn_raw(
+                    self.needles.as_ptr(),
+                    self.needles.len(),
+                    self.low_tab.as_ptr(),
+                    self.high_tab.as_ptr(),
+                    self.bit_mask,
+                    s,
+                    e,
+                )
+            })
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.it.size_hint()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -898,6 +1096,45 @@ mod tests {
         fn assert_send_sync<T: Send + Sync + UnwindSafe + RefUnwindSafe>() {}
         assert_send_sync::<Memchr>();
         assert_send_sync::<Memchr2>();
-        assert_send_sync::<Memchr3>()
+        assert_send_sync::<Memchr3>();
+        assert_send_sync::<MemchrN>();
+    }
+
+    #[test]
+    fn forwardn_iter() {
+        crate::tests::memchr::Runner::new(6).forward_iter(
+            |haystack, needles| {
+                Some(memchrn_iter(needles, haystack).collect())
+            },
+        )
+    }
+
+    #[test]
+    fn forwardn_oneshot() {
+        crate::tests::memchr::Runner::new(6).forward_oneshot(
+            |haystack, needles| Some(memchrn_iter(needles, haystack).next()),
+        )
+    }
+
+    #[test]
+    fn test_memchrn() {
+        fn test_one(needles: &[u8], haystack: &[u8], expect_cnt: usize) {
+            let memchrn = MultiByteFinder::new(needles).unwrap();
+            assert_eq!(memchrn.iter(haystack).into_iter().count(), expect_cnt);
+        }
+
+        let mut haystack = "@".repeat(14);
+        haystack.push_str("aa");
+        test_one(&[b'a'], haystack.as_bytes(), 2);
+
+        test_one(
+            &[196, 110, 1, 206, 192, 7, 39, 0],
+            &[
+                0, 0, 0, 0, 0, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99,
+                99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99,
+                99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 196, 63, 255,
+            ],
+            6,
+        );
     }
 }

--- a/src/tests/memchr/mod.rs
+++ b/src/tests/memchr/mod.rs
@@ -72,7 +72,6 @@ impl Runner {
     /// corresponds to the number of needle bytes to search for.
     pub(crate) fn new(needle_len: usize) -> Runner {
         assert!(needle_len >= 1, "needle_len must be at least 1");
-        assert!(needle_len <= 3, "needle_len must be at most 3");
         Runner { needle_len }
     }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -54,6 +54,7 @@ pub(crate) trait Vector: Copy + core::fmt::Debug {
     unsafe fn movemask(self) -> Self::Mask;
     /// _mm_cmpeq_epi8 or _mm256_cmpeq_epi8
     unsafe fn cmpeq(self, vector2: Self) -> Self;
+    unsafe fn cmpneq(self, vector2: Self) -> Self;
     /// _mm_and_si128 or _mm256_and_si256
     unsafe fn and(self, vector2: Self) -> Self;
     /// _mm_or or _mm256_or_si256
@@ -63,6 +64,18 @@ pub(crate) trait Vector: Copy + core::fmt::Debug {
     unsafe fn movemask_will_have_non_zero(self) -> bool {
         self.movemask().has_non_zero()
     }
+
+    /// shuffle bytes for table lookup
+    unsafe fn shuffle_bytes(self, indices: Self) -> Self;
+
+    /// Shift each 8-bit lane in this vector to the right by the number of
+    /// bits indictated by the `BITS` type parameter.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure that this is okay to call in the current target for
+    /// the current CPU.
+    unsafe fn shift_8bit_lane_right<const BITS: i32>(self) -> Self;
 }
 
 /// A trait that abstracts over a vector-to-scalar operation called
@@ -229,6 +242,12 @@ mod x86sse2 {
         }
 
         #[inline(always)]
+        unsafe fn cmpneq(self, vector2: Self) -> __m128i {
+            let eq = self.cmpeq(vector2);
+            _mm_andnot_si128(eq, _mm_set1_epi8(-1))
+        }
+
+        #[inline(always)]
         unsafe fn and(self, vector2: Self) -> __m128i {
             _mm_and_si128(self, vector2)
         }
@@ -236,6 +255,15 @@ mod x86sse2 {
         #[inline(always)]
         unsafe fn or(self, vector2: Self) -> __m128i {
             _mm_or_si128(self, vector2)
+        }
+
+        unsafe fn shuffle_bytes(self, indices: Self) -> Self {
+            _mm_shuffle_epi8(self, indices)
+        }
+
+        unsafe fn shift_8bit_lane_right<const BITS: i32>(self) -> Self {
+            let lomask = Self::splat(0xF);
+            _mm_srli_epi16(self, BITS).and(lomask)
         }
     }
 }
@@ -277,6 +305,11 @@ mod x86avx2 {
             _mm256_cmpeq_epi8(self, vector2)
         }
 
+        unsafe fn cmpneq(self, vector2: Self) -> Self {
+            let eq = self.cmpeq(vector2);
+            _mm256_andnot_si256(eq, _mm256_set1_epi8(-1))
+        }
+
         #[inline(always)]
         unsafe fn and(self, vector2: Self) -> __m256i {
             _mm256_and_si256(self, vector2)
@@ -285,6 +318,17 @@ mod x86avx2 {
         #[inline(always)]
         unsafe fn or(self, vector2: Self) -> __m256i {
             _mm256_or_si256(self, vector2)
+        }
+
+        #[inline(always)]
+        unsafe fn shuffle_bytes(self, indices: Self) -> Self {
+            _mm256_shuffle_epi8(self, indices)
+        }
+
+        #[inline(always)]
+        unsafe fn shift_8bit_lane_right<const BITS: i32>(self) -> Self {
+            let lomask = Self::splat(0xF);
+            _mm256_srli_epi16(self, BITS).and(lomask)
         }
     }
 }
@@ -333,6 +377,11 @@ mod aarch64neon {
         }
 
         #[inline(always)]
+        unsafe fn cmpneq(self, vector2: Self) -> uint8x16_t {
+            vmvnq_u8(self.cmpeq(vector2))
+        }
+
+        #[inline(always)]
         unsafe fn and(self, vector2: Self) -> uint8x16_t {
             vandq_u8(self, vector2)
         }
@@ -352,6 +401,17 @@ mod aarch64neon {
         unsafe fn movemask_will_have_non_zero(self) -> bool {
             let low = vreinterpretq_u64_u8(vpmaxq_u8(self, self));
             vgetq_lane_u64(low, 0) != 0
+        }
+
+        #[inline(always)]
+        unsafe fn shuffle_bytes(self, indices: Self) -> Self {
+            vqtbl1q_u8(self, indices)
+        }
+
+        #[inline(always)]
+        unsafe fn shift_8bit_lane_right<const BITS: i32>(self) -> Self {
+            debug_assert!(BITS <= 7);
+            vshrq_n_u8(self, BITS)
         }
     }
 
@@ -489,6 +549,11 @@ mod wasm_simd128 {
         }
 
         #[inline(always)]
+        unsafe fn cmpneq(self, vector2: Self) -> v128 {
+            v128_not(self.cmpeq(vector2))
+        }
+
+        #[inline(always)]
         unsafe fn and(self, vector2: Self) -> v128 {
             v128_and(self, vector2)
         }
@@ -496,6 +561,17 @@ mod wasm_simd128 {
         #[inline(always)]
         unsafe fn or(self, vector2: Self) -> v128 {
             v128_or(self, vector2)
+        }
+
+        #[inline(always)]
+        unsafe fn shuffle_bytes(self, indices: Self) -> Self {
+            i8x16_swizzle(self, indices)
+        }
+
+        #[inline(always)]
+        unsafe fn shift_8bit_lane_right<const BITS: i32>(self) -> Self {
+            debug_assert!(BITS <= 7 && BITS > 0);
+            u8x16_shr(self, BITS as u32)
         }
     }
 }


### PR DESCRIPTION
## What's this PR about? 

Implement shufti table based approach mentioned in https://github.com/BurntSushi/memchr/issues/206 to support memchr-N (N could be arbitrary usize as long as shufti algo allows)

## Background 

see https://github.com/BurntSushi/memchr/issues/206.

## Implementation

1. port `shuffle_bytes` and `shift_8bit_lane_right` methods from `aho_corasick`.
2. add `memchrn_iter, MemchrN` public API

This is still experimental, and it adds many overhead for maintenance. Perhaps a better approach is to create a separate crate named `memchr-n` to support this feature.

The purpose of this PR(now) is mainly for discussion since its quite a big change. Comments are welcomed. (But don't get trapped in current code style)