### PR TITLE
docs: fix typo in packed pair docs

### DIFF
--- a/src/arch/generic/packedpair.rs
+++ b/src/arch/generic/packedpair.rs
@@ -302,7 +302,7 @@ impl<V: Vector> Finder<V> {
 /// Accepts a chunk-relative offset and returns a haystack relative offset.
 ///
 /// This used to be marked `#[cold]` and `#[inline(never)]`, but I couldn't
-/// observe a consistent measureable difference between that and just inlining
+/// observe a consistent measurable difference between that and just inlining
 /// it. So we go with inlining it.
 ///
 /// # Safety


### PR DESCRIPTION
## Summary

Fix a typo in the packed pair documentation comment.

## Related issue

N/A. This is a trivial docs-only fix.

## Guideline alignment

No `CONTRIBUTING.md` or pull request template was present in the repository root or `.github` directory when this PR was prepared.

## Validation/testing

Not run. This is a documentation-comment-only change.
