### PR TITLE
docs: fix reuse wording in Finder comment

### DIFF
--- a/src/memmem/mod.rs
+++ b/src/memmem/mod.rs
@@ -372,7 +372,7 @@ impl<'h, 'n> Iterator for FindRevIter<'h, 'n> {
 /// The purpose of this type is to permit callers to construct a substring
 /// searcher that can be used to search haystacks without the overhead of
 /// constructing the searcher in the first place. This is a somewhat niche
-/// concern when it's necessary to re-use the same needle to search multiple
+/// concern when it's necessary to reuse the same needle to search multiple
 /// different haystacks with as little overhead as possible. In general, using
 /// [`find`] is good enough, but `Finder` is useful when you can meaningfully
 /// observe searcher construction time in a profile.


### PR DESCRIPTION
## Summary
- fix `re-use` -> `reuse` in the Finder comment

## Related issue
- N/A (trivial comment fix)

## Guideline alignment
- No `CONTRIBUTING` guide or PR template was found in this repository. This PR keeps the change to one focused, comment-only file with no behavior change.

## Validation/testing note
- Not run (comment-only change)
