### PR TITLE
Shorter is_available functions

### DIFF
--- a/src/arch/aarch64/neon/memchr.rs
+++ b/src/arch/aarch64/neon/memchr.rs
@@ -75,14 +75,7 @@ impl One {
     /// true then it will always return true.
     #[inline]
     pub fn is_available() -> bool {
-        #[cfg(target_feature = "neon")]
-        {
-            true
-        }
-        #[cfg(not(target_feature = "neon"))]
-        {
-            false
-        }
+        cfg!(target_feature = "neon")
     }
 
     /// Return the first occurrence of one of the needle bytes in the given
@@ -435,14 +428,7 @@ impl Two {
     /// true then it will always return true.
     #[inline]
     pub fn is_available() -> bool {
-        #[cfg(target_feature = "neon")]
-        {
-            true
-        }
-        #[cfg(not(target_feature = "neon"))]
-        {
-            false
-        }
+        cfg!(target_feature = "neon")
     }
 
     /// Return the first occurrence of one of the needle bytes in the given
@@ -721,14 +707,7 @@ impl Three {
     /// true then it will always return true.
     #[inline]
     pub fn is_available() -> bool {
-        #[cfg(target_feature = "neon")]
-        {
-            true
-        }
-        #[cfg(not(target_feature = "neon"))]
-        {
-            false
-        }
+        cfg!(target_feature = "neon")
     }
 
     /// Return the first occurrence of one of the needle bytes in the given

--- a/src/arch/aarch64/neon/packedpair.rs
+++ b/src/arch/aarch64/neon/packedpair.rs
@@ -88,14 +88,7 @@ impl Finder {
     /// true then it will always return true.
     #[inline]
     pub fn is_available() -> bool {
-        #[cfg(target_feature = "neon")]
-        {
-            true
-        }
-        #[cfg(not(target_feature = "neon"))]
-        {
-            false
-        }
+        cfg!(target_feature = "neon")
     }
 
     /// Execute a search using neon vectors and routines.

--- a/src/arch/wasm32/simd128/memchr.rs
+++ b/src/arch/wasm32/simd128/memchr.rs
@@ -70,14 +70,7 @@ impl One {
     /// true then it will always return true.
     #[inline]
     pub fn is_available() -> bool {
-        #[cfg(target_feature = "simd128")]
-        {
-            true
-        }
-        #[cfg(not(target_feature = "simd128"))]
-        {
-            false
-        }
+        cfg!(target_feature = "simd128")
     }
 
     /// Return the first occurrence of one of the needle bytes in the given
@@ -429,14 +422,7 @@ impl Two {
     /// true then it will always return true.
     #[inline]
     pub fn is_available() -> bool {
-        #[cfg(target_feature = "simd128")]
-        {
-            true
-        }
-        #[cfg(not(target_feature = "simd128"))]
-        {
-            false
-        }
+        cfg!(target_feature = "simd128")
     }
 
     /// Return the first occurrence of one of the needle bytes in the given
@@ -710,14 +696,7 @@ impl Three {
     /// true then it will always return true.
     #[inline]
     pub fn is_available() -> bool {
-        #[cfg(target_feature = "simd128")]
-        {
-            true
-        }
-        #[cfg(not(target_feature = "simd128"))]
-        {
-            false
-        }
+        cfg!(target_feature = "simd128")
     }
 
     /// Return the first occurrence of one of the needle bytes in the given

--- a/src/arch/x86_64/avx2/detect.rs
+++ b/src/arch/x86_64/avx2/detect.rs
@@ -1,0 +1,30 @@
+/// Returns true when AVX2 (and SSE2) are available in the current environment.
+///
+/// When AVX2 is enabled at compile time, this is a constant `true`. When it is
+/// not, runtime CPU feature detection is used if the `std` feature is enabled;
+/// otherwise this returns `false`.
+#[inline]
+pub(crate) fn has_avx2() -> bool {
+    #[cfg(not(target_feature = "sse2"))]
+    {
+        false
+    }
+    #[cfg(target_feature = "sse2")]
+    {
+        #[cfg(target_feature = "avx2")]
+        {
+            true
+        }
+        #[cfg(not(target_feature = "avx2"))]
+        {
+            #[cfg(feature = "std")]
+            {
+                std::is_x86_feature_detected!("avx2")
+            }
+            #[cfg(not(feature = "std"))]
+            {
+                false
+            }
+        }
+    }
+}

--- a/src/arch/x86_64/avx2/memchr.rs
+++ b/src/arch/x86_64/avx2/memchr.rs
@@ -84,28 +84,7 @@ impl One {
     /// true then it will always return true.
     #[inline]
     pub fn is_available() -> bool {
-        #[cfg(not(target_feature = "sse2"))]
-        {
-            false
-        }
-        #[cfg(target_feature = "sse2")]
-        {
-            #[cfg(target_feature = "avx2")]
-            {
-                true
-            }
-            #[cfg(not(target_feature = "avx2"))]
-            {
-                #[cfg(feature = "std")]
-                {
-                    std::is_x86_feature_detected!("avx2")
-                }
-                #[cfg(not(feature = "std"))]
-                {
-                    false
-                }
-            }
-        }
+        crate::arch::x86_64::avx2::detect::has_avx2()
     }
 
     /// Return the first occurrence of one of the needle bytes in the given
@@ -571,28 +550,7 @@ impl Two {
     /// true then it will always return true.
     #[inline]
     pub fn is_available() -> bool {
-        #[cfg(not(target_feature = "sse2"))]
-        {
-            false
-        }
-        #[cfg(target_feature = "sse2")]
-        {
-            #[cfg(target_feature = "avx2")]
-            {
-                true
-            }
-            #[cfg(not(target_feature = "avx2"))]
-            {
-                #[cfg(feature = "std")]
-                {
-                    std::is_x86_feature_detected!("avx2")
-                }
-                #[cfg(not(feature = "std"))]
-                {
-                    false
-                }
-            }
-        }
+        crate::arch::x86_64::avx2::detect::has_avx2()
     }
 
     /// Return the first occurrence of one of the needle bytes in the given
@@ -954,28 +912,7 @@ impl Three {
     /// true then it will always return true.
     #[inline]
     pub fn is_available() -> bool {
-        #[cfg(not(target_feature = "sse2"))]
-        {
-            false
-        }
-        #[cfg(target_feature = "sse2")]
-        {
-            #[cfg(target_feature = "avx2")]
-            {
-                true
-            }
-            #[cfg(not(target_feature = "avx2"))]
-            {
-                #[cfg(feature = "std")]
-                {
-                    std::is_x86_feature_detected!("avx2")
-                }
-                #[cfg(not(feature = "std"))]
-                {
-                    false
-                }
-            }
-        }
+        crate::arch::x86_64::avx2::detect::has_avx2()
     }
 
     /// Return the first occurrence of one of the needle bytes in the given

--- a/src/arch/x86_64/avx2/mod.rs
+++ b/src/arch/x86_64/avx2/mod.rs
@@ -2,5 +2,6 @@
 Algorithms for the `x86_64` target using 256-bit vectors via AVX2.
 */
 
+pub(crate) mod detect;
 pub mod memchr;
 pub mod packedpair;

--- a/src/arch/x86_64/avx2/packedpair.rs
+++ b/src/arch/x86_64/avx2/packedpair.rs
@@ -85,28 +85,7 @@ impl Finder {
     /// true then it will always return true.
     #[inline]
     pub fn is_available() -> bool {
-        #[cfg(not(target_feature = "sse2"))]
-        {
-            false
-        }
-        #[cfg(target_feature = "sse2")]
-        {
-            #[cfg(target_feature = "avx2")]
-            {
-                true
-            }
-            #[cfg(not(target_feature = "avx2"))]
-            {
-                #[cfg(feature = "std")]
-                {
-                    std::is_x86_feature_detected!("avx2")
-                }
-                #[cfg(not(feature = "std"))]
-                {
-                    false
-                }
-            }
-        }
+        crate::arch::x86_64::avx2::detect::has_avx2()
     }
 
     /// Execute a search using AVX2 vectors and routines.

--- a/src/arch/x86_64/sse2/memchr.rs
+++ b/src/arch/x86_64/sse2/memchr.rs
@@ -75,14 +75,7 @@ impl One {
     /// true then it will always return true.
     #[inline]
     pub fn is_available() -> bool {
-        #[cfg(target_feature = "sse2")]
-        {
-            true
-        }
-        #[cfg(not(target_feature = "sse2"))]
-        {
-            false
-        }
+        cfg!(target_feature = "sse2")
     }
 
     /// Return the first occurrence of one of the needle bytes in the given
@@ -451,14 +444,7 @@ impl Two {
     /// true then it will always return true.
     #[inline]
     pub fn is_available() -> bool {
-        #[cfg(target_feature = "sse2")]
-        {
-            true
-        }
-        #[cfg(not(target_feature = "sse2"))]
-        {
-            false
-        }
+        cfg!(target_feature = "sse2")
     }
 
     /// Return the first occurrence of one of the needle bytes in the given
@@ -752,14 +738,7 @@ impl Three {
     /// true then it will always return true.
     #[inline]
     pub fn is_available() -> bool {
-        #[cfg(target_feature = "sse2")]
-        {
-            true
-        }
-        #[cfg(not(target_feature = "sse2"))]
-        {
-            false
-        }
+        cfg!(target_feature = "sse2")
     }
 
     /// Return the first occurrence of one of the needle bytes in the given

--- a/src/arch/x86_64/sse2/packedpair.rs
+++ b/src/arch/x86_64/sse2/packedpair.rs
@@ -81,14 +81,7 @@ impl Finder {
     /// true then it will always return true.
     #[inline]
     pub fn is_available() -> bool {
-        #[cfg(not(target_feature = "sse2"))]
-        {
-            false
-        }
-        #[cfg(target_feature = "sse2")]
-        {
-            true
-        }
+        cfg!(target_feature = "sse2")
     }
 
     /// Execute a search using SSE2 vectors and routines.


### PR DESCRIPTION
- replace cfg blocks with cfg expressions
- extract repetitive avx2 detection blocks in a function