### PR TITLE
Fix minor UB flagged by miri

### DIFF
--- a/src/arch/generic/packedpair.rs
+++ b/src/arch/generic/packedpair.rs
@@ -223,8 +223,9 @@ impl<V: Vector> Finder<V> {
     /// # Safety
     ///
     /// It must be safe to do an unaligned read of size(V) bytes starting at
-    /// both (cur + self.index1) and (cur + self.index2). It must also be safe
-    /// to do unaligned loads on cur up to (end - needle.len()).
+    /// both (cur + self.index1) and (cur + self.index2). `cur` and `end`
+    /// must point into the same allocation, with every candidate offset
+    /// reported by the vector mask keeping `cur.add(offset) < end`.
     #[inline(always)]
     unsafe fn find_in_chunk(
         &self,
@@ -244,7 +245,7 @@ impl<V: Vector> Finder<V> {
         while offsets.has_non_zero() {
             let offset = offsets.first_offset();
             let cur = cur.add(offset);
-            if end.sub(needle.len()) < cur {
+            if needle.len() > end.distance(cur) {
                 return None;
             }
             if is_equal_raw(needle.as_ptr(), cur, needle.len()) {

--- a/src/arch/x86_64/sse2/packedpair.rs
+++ b/src/arch/x86_64/sse2/packedpair.rs
@@ -229,4 +229,21 @@ mod tests {
         }
         crate::tests::packedpair::Runner::new().fwd(find).run()
     }
+
+    #[cfg(miri)]
+    #[test]
+    fn miri_ub_mismatched_needle_longer_than_haystack() {
+        // Soundness issue: `Finder::find` is a safe public method that accepts
+        // a `needle` slice at search time, but the underlying vector finder
+        // only validates the haystack against the needle used at construction
+        // time. Passing a longer search-time needle can make
+        // `generic::packedpair::Finder::find_in_chunk` compute
+        // `end.sub(needle.len())` before the start of `haystack`, which is UB.
+        let pair = Pair::with_indices(b"ab", 0, 1).unwrap();
+        let finder = Finder::with_pair(b"ab", pair).unwrap();
+        let haystack = b"abxxxxxxxxxxxxxxx";
+        let needle = b"abcdefghijklmnopqr";
+
+        let _ = finder.find(haystack, needle);
+    }
 }


### PR DESCRIPTION
Fixed UB in the generic packed-pair finder when the safe `Finder::find` API is called with a search-time needle longer than the haystack.

Although callers are documented to pass the same needle used at construction time, this is still a safe API. A mismatched longer needle could make `find_in_chunk` evaluate `end.sub(needle.len())`, creating a pointer before the start of the haystack allocation. That pointer was only used for comparison, not dereferenced, so ASan does not catch it, but Miri reports it as UB.

The fix checks the remaining byte length from the candidate pointer to `end` before forming any pointer derived from `end`. If the search-time needle cannot fit, the function now returns `None` without invalid pointer arithmetic. This is verified with a Miri regression test.