### PR TITLE
chore: improve memchr maintenance path

### DIFF
--- a/src/arch/all/memchr.rs
+++ b/src/arch/all/memchr.rs
@@ -1019,4 +1019,72 @@ mod tests {
         let data = [0, 0, 0, 0, 0, 0, 0, 0];
         assert_eq!(One::new(b'\x00').find(&data), Some(0));
     }
+
+    #[test]
+    fn edge_empty_haystack() {
+        assert_eq!(One::new(b'a').find(b""), None);
+        assert_eq!(One::new(b'a').rfind(b""), None);
+        assert_eq!(Two::new(b'a', b'b').find(b""), None);
+        assert_eq!(Two::new(b'a', b'b').rfind(b""), None);
+        assert_eq!(Three::new(b'a', b'b', b'c').find(b""), None);
+        assert_eq!(Three::new(b'a', b'b', b'c').rfind(b""), None);
+    }
+
+    #[test]
+    fn edge_single_byte_haystack() {
+        assert_eq!(One::new(b'a').find(b"a"), Some(0));
+        assert_eq!(One::new(b'a').find(b"z"), None);
+        assert_eq!(One::new(b'a').rfind(b"a"), Some(0));
+        assert_eq!(One::new(b'a').rfind(b"z"), None);
+
+        assert_eq!(Two::new(b'a', b'b').find(b"a"), Some(0));
+        assert_eq!(Two::new(b'a', b'b').find(b"z"), None);
+        assert_eq!(Two::new(b'a', b'b').rfind(b"a"), Some(0));
+        assert_eq!(Two::new(b'a', b'b').rfind(b"z"), None);
+
+        assert_eq!(Three::new(b'a', b'b', b'c').find(b"a"), Some(0));
+        assert_eq!(Three::new(b'a', b'b', b'c').find(b"z"), None);
+        assert_eq!(Three::new(b'a', b'b', b'c').rfind(b"a"), Some(0));
+        assert_eq!(Three::new(b'a', b'b', b'c').rfind(b"z"), None);
+    }
+
+    #[test]
+    fn edge_boundary_alignment() {
+        let usz = core::mem::size_of::<usize>();
+
+        // Match in the first unaligned chunk: short-circuit path.
+        let all_zs = vec![b'z'; usz];
+        assert_eq!(One::new(b'z').find(&all_zs), Some(0));
+        assert_eq!(One::new(b'z').rfind(&all_zs), Some(usz - 1));
+
+        // Match is not in the first chunk, forcing the aligned forward path.
+        let mut hay = vec![b'a'; usz];
+        hay.push(b'z');
+        assert_eq!(One::new(b'z').find(&hay), Some(usz));
+
+        // Length exactly LOOP_BYTES (2 * USIZE_BYTES).
+        let mut hay = vec![b'a'; usz];
+        hay.extend(vec![b'z'; usz]);
+        assert_eq!(One::new(b'z').find(&hay), Some(usz));
+        assert_eq!(One::new(b'z').rfind(&hay), Some(2 * usz - 1));
+
+        // Length just above LOOP_BYTES for One.
+        let mut hay = vec![b'a'; usz + 1];
+        hay.extend(vec![b'z'; usz]);
+        assert_eq!(One::new(b'z').find(&hay), Some(usz + 1));
+        assert_eq!(One::new(b'z').rfind(&hay), Some(2 * usz));
+
+        // Match is not in the last chunk, forcing the aligned reverse path.
+        let mut hay = vec![b'z'; usz];
+        hay.extend(vec![b'a'; usz + 1]);
+        assert_eq!(One::new(b'z').rfind(&hay), Some(usz - 1));
+
+        // Two/Three aligned loop path.
+        let mut hay = vec![b'a'; usz];
+        hay.extend(vec![b'z'; usz]);
+        assert_eq!(Two::new(b'z', b'y').find(&hay), Some(usz));
+        assert_eq!(Two::new(b'z', b'y').rfind(&hay), Some(2 * usz - 1));
+        assert_eq!(Three::new(b'z', b'y', b'x').find(&hay), Some(usz));
+        assert_eq!(Three::new(b'z', b'y', b'x').rfind(&hay), Some(2 * usz - 1));
+    }
 }

--- a/src/arch/all/packedpair/mod.rs
+++ b/src/arch/all/packedpair/mod.rs
@@ -54,6 +54,7 @@ impl Finder {
     /// bytes is used as a predicate.
     #[inline]
     pub fn with_pair(needle: &[u8], pair: Pair) -> Option<Finder> {
+        debug_assert!(needle.len() >= 2, "needle must have length at least 2");
         let byte1 = needle[usize::from(pair.index1())];
         let byte2 = needle[usize::from(pair.index2())];
         // Currently this can never fail so we could just return a Finder,
@@ -355,5 +356,15 @@ mod tests {
             Some(f.find_prefilter(haystack))
         }
         crate::tests::packedpair::Runner::new().fwd(find).run()
+    }
+
+    #[test]
+    fn empty_needle() {
+        assert!(Finder::new(b"").is_none());
+    }
+
+    #[test]
+    fn single_byte_needle() {
+        assert!(Finder::new(b"x").is_none());
     }
 }


### PR DESCRIPTION
Summary:
- Add additional edge-case unit tests in the existing #[cfg(test)] modules covering empty-needle, single-byte haystack, and boundary alignment cases for the generic (all-arch) memchr/packedpair fallback paths, plus a debug_assert for needle length invariants at one public entry point where the invariant is currently only implicit. Pure additive tests and one narrow assertion — no behavior change.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.