### PR TITLE
Fix NeonMoveMask and align naming with actual semantics

### DIFF
--- a/src/arch/generic/packedpair.rs
+++ b/src/arch/generic/packedpair.rs
@@ -89,7 +89,7 @@ impl<V: Vector> Finder<V> {
             haystack.len(),
         );
 
-        let all = V::Mask::all_zeros_except_least_significant(0);
+        let all = V::Mask::all_ones_except_least_significant(0);
         let start = haystack.as_ptr();
         let end = start.add(haystack.len());
         let max = end.sub(self.min_haystack_len);
@@ -139,7 +139,7 @@ impl<V: Vector> Finder<V> {
             // significant bits, where N=overlap. This way, any matches that
             // occur in find_in_chunk within the overlap are automatically
             // ignored.
-            let mask = V::Mask::all_zeros_except_least_significant(overlap);
+            let mask = V::Mask::all_ones_except_least_significant(overlap);
             cur = max;
             let m = self.find_in_chunk(needle, cur, end, mask);
             if let Some(chunki) = m {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod memchr;
 pub(crate) mod packedpair;
 #[macro_use]
 pub(crate) mod substring;
+pub(crate) mod vector;
 
 // For debugging, particularly in CI, print out the byte order of the current
 // target.

--- a/src/tests/vector.rs
+++ b/src/tests/vector.rs
@@ -21,12 +21,18 @@ mod tests {
     #[test]
     fn first_offset() {
         #[cfg(target_arch = "aarch64")]
-        test_move_mask_first_offset::<<std::arch::aarch64::uint8x16_t as Vector>::Mask, 16>();
+        test_move_mask_first_offset::<
+            <std::arch::aarch64::uint8x16_t as Vector>::Mask,
+            16,
+        >();
     }
 
     #[test]
     fn clear_first_offset() {
         #[cfg(target_arch = "aarch64")]
-        test_move_mask_clear_first_offset::<<std::arch::aarch64::uint8x16_t as Vector>::Mask, 16>();
+        test_move_mask_clear_first_offset::<
+            <std::arch::aarch64::uint8x16_t as Vector>::Mask,
+            16,
+        >();
     }
 }

--- a/src/tests/vector.rs
+++ b/src/tests/vector.rs
@@ -1,0 +1,32 @@
+use crate::vector::{MoveMask, Vector};
+
+fn test_move_mask_first_offset<M: MoveMask, const SIZE: usize>() {
+    for n in 0usize..SIZE {
+        let n_zeros = M::all_ones_except_least_significant(n);
+        assert_eq!(n_zeros.first_offset(), n);
+    }
+}
+
+fn test_move_mask_clear_first_offset<M: MoveMask, const SIZE: usize>() {
+    for n in 0usize..SIZE {
+        let n_zeros = M::all_ones_except_least_significant(n);
+        assert_ne!(n_zeros.clear_least_significant_bit().first_offset(), n);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_offset() {
+        #[cfg(target_arch = "aarch64")]
+        test_move_mask_first_offset::<<std::arch::aarch64::uint8x16_t as Vector>::Mask, 16>();
+    }
+
+    #[test]
+    fn clear_first_offset() {
+        #[cfg(target_arch = "aarch64")]
+        test_move_mask_clear_first_offset::<<std::arch::aarch64::uint8x16_t as Vector>::Mask, 16>();
+    }
+}

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -80,9 +80,9 @@ pub(crate) trait Vector: Copy + core::fmt::Debug {
 /// for `memchr` and `packedpair`. So instead, we abstraction over the specific
 /// representation with this trait and define the operations we actually need.
 pub(crate) trait MoveMask: Copy + core::fmt::Debug {
-    /// Return a mask that is all zeros except for the least significant `n`
+    /// Return a mask that is all ones except for the least significant `n`
     /// lanes in a corresponding vector.
-    fn all_zeros_except_least_significant(n: usize) -> Self;
+    fn all_ones_except_least_significant(n: usize) -> Self;
 
     /// Returns true if and only if this mask has a a non-zero bit anywhere.
     fn has_non_zero(self) -> bool;
@@ -137,9 +137,9 @@ impl SensibleMoveMask {
 
 impl MoveMask for SensibleMoveMask {
     #[inline(always)]
-    fn all_zeros_except_least_significant(n: usize) -> SensibleMoveMask {
+    fn all_ones_except_least_significant(n: usize) -> SensibleMoveMask {
         debug_assert!(n < 32);
-        SensibleMoveMask(!((1 << n) - 1))
+        SensibleMoveMask(0xFFFFFFFF << n)
     }
 
     #[inline(always)]
@@ -385,9 +385,9 @@ mod aarch64neon {
 
     impl MoveMask for NeonMoveMask {
         #[inline(always)]
-        fn all_zeros_except_least_significant(n: usize) -> NeonMoveMask {
+        fn all_ones_except_least_significant(n: usize) -> NeonMoveMask {
             debug_assert!(n < 16);
-            NeonMoveMask(!(((1 << n) << 2) - 1))
+            NeonMoveMask(0x8888888888888888 << (n << 2))
         }
 
         #[inline(always)]


### PR DESCRIPTION
Fixes #219 

I also updated the naming to align with the semantics, given by the comment "The mask has all of its bits **set** except for the first N least significant bits", and saved a few bit ops.