### PR TITLE
fix aarch64_be endianness bug

### DIFF
--- a/src/vector.rs
+++ b/src/vector.rs
@@ -319,11 +319,24 @@ mod aarch64neon {
         }
 
         #[inline(always)]
+        #[cfg(target_endian = "little")]
         unsafe fn movemask(self) -> NeonMoveMask {
             let asu16s = vreinterpretq_u16_u8(self);
             let mask = vshrn_n_u16(asu16s, 4);
             let asu64 = vreinterpret_u64_u8(mask);
             let scalar64 = vget_lane_u64(asu64, 0);
+            NeonMoveMask(scalar64 & 0x8888888888888888)
+        }
+
+        #[inline(always)]
+        #[cfg(target_endian = "big")]
+        unsafe fn movemask(self) -> NeonMoveMask {
+            // Swap the endianness of each 16-bit input.
+            let asu16s = vreinterpretq_u16_u8(vrev16q_u8(self));
+            let mask = vshrn_n_u16(asu16s, 4);
+            let asu64 = vreinterpret_u64_u8(mask);
+            // Use `swap_bytes` to swap the endianness of the 64-bit output.
+            let scalar64 = vget_lane_u64(asu64, 0).swap_bytes();
             NeonMoveMask(scalar64 & 0x8888888888888888)
         }
 


### PR DESCRIPTION
Fixes the bug reported in https://github.com/rust-lang/miri/issues/5056 and discussed in [#general > Failling CI with `aarch64_be-unknown-linux-gnu` and nightly @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/122651-general/topic/Failling.20CI.20with.20.60aarch64_be-unknown-linux-gnu.60.20and.20nightly/near/596575288). A recent change in `rust-lang/stdarch` fixed various big-endian operations, breaking this crate on the target. 

The fix is to effectively swap the input and the output, so that the rest of the library does not need to worry about endianness. With this change, the whole test suite passes with aarch64_be run with qemu.

We do run tests for aarch64_be in stdarch CI (see https://github.com/rust-lang/stdarch/blob/main/ci/docker/aarch64_be-unknown-linux-gnu/Dockerfile specifically the curl command that downloads the toolchain). But also it's a tier-3 target so maybe that's too much hassle.
