### PR TITLE
Remove unnecessary clones

### DIFF
--- a/src/memmem/mod.rs
+++ b/src/memmem/mod.rs
@@ -468,10 +468,7 @@ impl<'n> Finder<'n> {
     #[cfg(feature = "alloc")]
     #[inline]
     pub fn into_owned(self) -> Finder<'static> {
-        Finder {
-            needle: self.needle.into_owned(),
-            searcher: self.searcher.clone(),
-        }
+        Finder { needle: self.needle.into_owned(), searcher: self.searcher }
     }
 
     /// Convert this finder into its borrowed variant.
@@ -606,10 +603,7 @@ impl<'n> FinderRev<'n> {
     #[cfg(feature = "alloc")]
     #[inline]
     pub fn into_owned(self) -> FinderRev<'static> {
-        FinderRev {
-            needle: self.needle.into_owned(),
-            searcher: self.searcher.clone(),
-        }
+        FinderRev { needle: self.needle.into_owned(), searcher: self.searcher }
     }
 
     /// Convert this finder into its borrowed variant.


### PR DESCRIPTION
If I am not overlooking anything, the clones inside these `into_owned` functions can be safely deleted.

CC @nunoplopes