### PR TITLE
arch: fix undefined behavior in lower level (but public) APIs

### DIFF
--- a/src/arch/generic/packedpair.rs
+++ b/src/arch/generic/packedpair.rs
@@ -244,7 +244,7 @@ impl<V: Vector> Finder<V> {
         while offsets.has_non_zero() {
             let offset = offsets.first_offset();
             let cur = cur.add(offset);
-            if end.sub(needle.len()) < cur {
+            if end.distance(cur) < needle.len() {
                 return None;
             }
             if is_equal_raw(needle.as_ptr(), cur, needle.len()) {

--- a/src/arch/x86_64/sse2/packedpair.rs
+++ b/src/arch/x86_64/sse2/packedpair.rs
@@ -229,4 +229,25 @@ mod tests {
         }
         crate::tests::packedpair::Runner::new().fwd(find).run()
     }
+
+    // A demonstration of UB (caught under Miri) through some of memchr's
+    // lower level but public APIs.
+    //
+    // See: https://github.com/BurntSushi/memchr/issues/225
+    #[test]
+    fn regression_undefined_behavior() {
+        let construct_needle: &[u8] = b"ab"; // length 2 → pair indices 0,1
+        let pair = Pair::new(construct_needle).unwrap();
+        let Some(finder) = Finder::with_pair(construct_needle, pair) else {
+            return;
+        };
+        let mhl = finder.min_haystack_len(); // 17
+        let mut haystack = alloc::vec![b'.'; mhl + 5];
+        haystack[0] = b'a';
+        // force entry into find_in_chunk inner branch
+        haystack[1] = b'b';
+        // 122 > haystack.len()=22
+        let long_needle = alloc::vec![b'X'; haystack.len() + 100];
+        let _ = finder.find(&haystack, &long_needle);
+    }
 }


### PR DESCRIPTION
The main hitch here is that the lower level APIs require the caller to
pass the needle in both the constructor and the search routine. The
constructor does some pre-computation based on that needle that the
surrounding code relied upon for soundness. If the caller passes in a
different needle than what was given to the constructor, then one could
trigger undefined behavior.

This likely falls under "malicious caller" because it would be odd for
the caller to not follow the documented contract (by passing two
different needles). However, the contract is not a safety invariant and
the routine is not marked `unsafe`. So this API was just plain unsound.

The fix is thankfully very easy: subtract `cur` from `end` to get a
distance between the pointers and compare that with the needle length.
The invariant between `cur` and `end` is not dependent on the needle, so
this subtraction is always safe.

Fixes #225
