### PR TITLE
let compiler know that indexes returned by memchr fns are in bounds

### DIFF
--- a/src/arch/generic/memchr.rs
+++ b/src/arch/generic/memchr.rs
@@ -1132,7 +1132,13 @@ pub(crate) unsafe fn search_slice_with_raw(
     let start = haystack.as_ptr();
     let end = start.add(haystack.len());
     let found = find_raw(start, end)?;
-    Some(found.distance(start))
+    let idx = found.distance(start);
+    // Required by safety invariant required for find_raw
+    // this lets the compiler know the returned index is in bounds for the slice
+    if idx >= haystack.len() {
+        core::hint::unreachable_unchecked();
+    }
+    Some(idx)
 }
 
 /// Performs a forward byte-at-a-time loop until either `ptr >= end_ptr` or


### PR DESCRIPTION
For example, in code like:

```rust
let len = memchr::memchr(b'\0', slice).unwrap_or(slice.len());
&slice[..len]
```

Without this change, there is a potential panic at `&slice[..len]`, but with this change, rust knows the len must be valid, and no longer adds the potential panic.

Same as #196, but without needing to bump MSRV

Closes #196
Closes #195